### PR TITLE
Clear post-merge Sonar hotspot and Codacy findings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 
 project = 'AutoControl'
-copyright = '2020 ~ Now, JE-Chen'  # noqa: A001  # reason: Sphinx-required name
+copyright = '2020 ~ Now, JE-Chen'  # noqa: A001  # pylint: disable=redefined-builtin  # reason: Sphinx-required name
 author = 'JE-Chen'
 release = '0.0.179'
 

--- a/je_auto_control/utils/clipboard/clipboard.py
+++ b/je_auto_control/utils/clipboard/clipboard.py
@@ -143,6 +143,7 @@ def _linux_get() -> str:
     if cmd is None:
         raise RuntimeError("Install xclip or xsel for Linux clipboard support")
     read_cmd = cmd + ["-o"] if cmd[0] == "xclip" else cmd + ["--output"]
+    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
     result = subprocess.run(  # nosec B603  # reason: argv from allowlist (xclip/xsel) discovered via shutil.which
         read_cmd, capture_output=True, check=True, timeout=5,
     )
@@ -154,6 +155,7 @@ def _linux_set(text: str) -> None:
     if cmd is None:
         raise RuntimeError("Install xclip or xsel for Linux clipboard support")
     write_cmd = cmd + ["-i"] if cmd[0] == "xclip" else cmd + ["--input"]
+    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
     subprocess.run(  # nosec B603  # reason: argv from allowlist (xclip/xsel) discovered via shutil.which
         write_cmd, input=text.encode("utf-8"),
         check=True, timeout=5,

--- a/je_auto_control/utils/rest_api/rest_server.py
+++ b/je_auto_control/utils/rest_api/rest_server.py
@@ -25,9 +25,9 @@ class _JSONHandler(BaseHTTPRequestHandler):
     server_version = "AutoControlREST/1.0"
 
     # Suppress default stderr access logs — route through the project logger.
-    def log_message(self, fmt: str, *args: Any) -> None:
+    def log_message(self, format, *args) -> None:  # noqa: A002  # pylint: disable=redefined-builtin  # reason: stdlib BaseHTTPRequestHandler override
         autocontrol_logger.info("rest-api %s - %s",
-                                self.address_string(), fmt % args)
+                                self.address_string(), format % args)
 
     def do_GET(self) -> None:  # noqa: N802  # reason: stdlib API
         parsed = urlparse(self.path)

--- a/je_auto_control/utils/shell_process/shell_exec.py
+++ b/je_auto_control/utils/shell_process/shell_exec.py
@@ -51,6 +51,7 @@ class ShellManager:
         try:
             self.exit_program()
             args = _normalize_command(shell_command)
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
             self.process = subprocess.Popen(  # nosec B603  # reason: shell=False, argv list validated via _normalize_command
                 args,
                 stdout=subprocess.PIPE,

--- a/test/unit_test/headless/test_rest_server.py
+++ b/test/unit_test/headless/test_rest_server.py
@@ -16,9 +16,12 @@ def rest_server():
     server.stop(timeout=1.0)
 
 
+_TEST_SCHEME = "http"  # NOSONAR: S5332  # reason: localhost-only ephemeral test server; TLS is out of scope here
+
+
 def _request(server, path, method="GET", body=None):
     host, port = server.address
-    url = f"http://{host}:{port}{path}"
+    url = f"{_TEST_SCHEME}://{host}:{port}{path}"
     data = None
     headers = {}
     if body is not None:


### PR DESCRIPTION
## Summary

Two small analyzer follow-ups caught after PR #175 merged.

- **Sonar hotspot S5332** — ``test_rest_server.py:21``: extract ``_TEST_SCHEME = "http"`` constant with a ``NOSONAR`` justification. The test hits an ephemeral localhost server on port 0; TLS is out of scope.
- **Codacy main-branch issues (5 total)** — one-line suppressions or signature alignments for:
  - ``conf.py`` ``redefined-builtin`` on Sphinx's required ``copyright`` global (PyLint W0622)
  - ``_JSONHandler.log_message`` signature lined up with ``BaseHTTPRequestHandler.log_message`` (W0221)
  - ``nosemgrep`` on the three dynamic-argv subprocess calls in ``clipboard._linux_get``/``_linux_set`` and ``shell_exec.exec_shell`` — argv is allowlisted via ``shutil.which`` or validated by ``_normalize_command``

## Test plan

- [x] ``python -m pytest test/unit_test/headless test/unit_test/flow_control`` — 139 passed locally
- [x] ``python -m ruff check je_auto_control/ test/`` — clean
- [x] ``python -m bandit -r je_auto_control/ -c pyproject.toml`` — 0 issues
- [ ] Sonar + Codacy re-analysis on merge commit reports no new findings