### PR TITLE
Clear 8 remaining Sonar findings on main

### DIFF
--- a/je_auto_control/utils/clipboard/clipboard.py
+++ b/je_auto_control/utils/clipboard/clipboard.py
@@ -93,14 +93,14 @@ def _win_set(text: str) -> None:
     kernel32.GlobalUnlock.argtypes = [wintypes.HGLOBAL]
 
     data = ctypes.create_unicode_buffer(text)
-    size = ctypes.sizeof(data)
+    size = ctypes.sizeof(data)  # NOSONAR S5655 false positive — Array is accepted by sizeof
     handle = kernel32.GlobalAlloc(gmem_moveable, size)
     if not handle:
         raise RuntimeError("GlobalAlloc failed")
     pointer = kernel32.GlobalLock(handle)
     if not pointer:
         raise RuntimeError("GlobalLock failed")
-    ctypes.memmove(pointer, ctypes.addressof(data), size)
+    ctypes.memmove(pointer, ctypes.addressof(data), size)  # NOSONAR S5655 false positive — Array is accepted by addressof
     kernel32.GlobalUnlock(handle)
     if not user32.OpenClipboard(None):
         raise RuntimeError("OpenClipboard failed")

--- a/je_auto_control/windows/listener/win32_keyboard_listener.py
+++ b/je_auto_control/windows/listener/win32_keyboard_listener.py
@@ -90,7 +90,7 @@ class Win32KeyboardListener(Thread):
 
         message = MSG()
         # 進入訊息迴圈 Enter message loop
-        _user32.GetMessageA(byref(message), 0, 0, 0)
+        _user32.GetMessageA(byref(message), 0, 0, 0)  # NOSONAR S5655 false positive — MSG is a ctypes Structure
 
     def record(self, want_to_record_queue: Queue) -> None:
         """

--- a/je_auto_control/windows/listener/win32_mouse_listener.py
+++ b/je_auto_control/windows/listener/win32_mouse_listener.py
@@ -99,7 +99,7 @@ class Win32MouseListener(Thread):
             raise AutoControlException("Failed to set mouse hook")
 
         message = MSG()
-        _user32.GetMessageA(byref(message), 0, 0, 0)
+        _user32.GetMessageA(byref(message), 0, 0, 0)  # NOSONAR S5655 false positive — MSG is a ctypes Structure
 
     def record(self, want_to_record_queue: Queue) -> None:
         """

--- a/test/unit_test/headless/test_plugin_loader.py
+++ b/test/unit_test/headless/test_plugin_loader.py
@@ -73,10 +73,10 @@ def test_register_plugin_commands_adds_and_removes_cleanly(tmp_path):
 
 def test_discover_ignores_non_callable_ac_attribute():
     class Module:
-        AC_value = 42  # noqa: N815  # reason: AC_* is the plugin contract
+        AC_value = 42  # noqa: N815  # NOSONAR AC_* is the plugin contract
 
         @staticmethod
-        def AC_run():  # noqa: N802  # reason: AC_* is the plugin contract
+        def AC_run():  # noqa: N802  # NOSONAR AC_* is the plugin contract
             return 1
 
     found = discover_plugin_commands(Module)

--- a/test/unit_test/headless/test_rest_server.py
+++ b/test/unit_test/headless/test_rest_server.py
@@ -16,7 +16,7 @@ def rest_server():
     server.stop(timeout=1.0)
 
 
-_TEST_SCHEME = "http"  # NOSONAR: S5332  # reason: localhost-only ephemeral test server; TLS is out of scope here
+_TEST_SCHEME = "http"  # NOSONAR localhost-only ephemeral test server; TLS is out of scope here
 
 
 def _request(server, path, method="GET", body=None):

--- a/test/unit_test/headless/test_watcher.py
+++ b/test/unit_test/headless/test_watcher.py
@@ -46,8 +46,11 @@ def test_mouse_watcher_reports_failure(monkeypatch):
 
 def test_pixel_watcher_returns_none_on_error(monkeypatch):
     import je_auto_control.wrapper.auto_control_screen as screen_mod
-    monkeypatch.setattr(screen_mod, "get_pixel",
-                        lambda x, y: (_ for _ in ()).throw(OSError("nope")))
+
+    def _raise_os_error(_x, _y):
+        raise OSError("nope")
+
+    monkeypatch.setattr(screen_mod, "get_pixel", _raise_os_error)
     assert PixelWatcher().sample(0, 0) is None
 
 


### PR DESCRIPTION
## Summary

Single-commit follow-up. Closes the last 8 Sonar issues reporting OPEN/CONFIRMED on ``main``.

- **S5655 (4) — ctypes false positives**: ``# NOSONAR`` on ``ctypes.sizeof``/``addressof``/``byref`` calls where Sonar's type checker can't prove ``Array``/``Structure`` satisfy the ``_CData`` contract. (``clipboard.py:96,103``; ``win32_keyboard_listener.py:93``; ``win32_mouse_listener.py:102``)
- **S7632** — fix the suppression comment syntax on ``test_rest_server.py:19`` (Sonar-Python expects ``# NOSONAR <free text>``, no colon).
- **S116 / S100** — add ``# NOSONAR AC_* is the plugin contract`` next to the existing noqa for ``AC_value`` / ``AC_run`` in ``test_plugin_loader.py``.
- **S7500** — replace the ``(_ for _ in ()).throw(OSError(...))`` generator trick in ``test_watcher.py`` with a plain ``def _raise_os_error`` helper.

## Test plan

- [x] ``python -m pytest test/unit_test/headless test/unit_test/flow_control`` — 139 passed locally
- [x] ``python -m ruff check je_auto_control/ test/`` — clean
- [ ] Sonar re-scan on merge reports 0 open/confirmed issues