### PR TITLE
Fix stable CI publish job being skipped

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -118,7 +118,7 @@ jobs:
 
   publish:
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -182,8 +182,8 @@ jobs:
           git add pyproject.toml
           git commit -m "Bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
           git tag "v${{ steps.bump.outputs.new_version }}"
-          git pull --rebase origin stable
-          git push origin stable
+          git pull --rebase origin main
+          git push origin main
           git push origin "v${{ steps.bump.outputs.new_version }}"
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- Publish job in `stable.yml` was gated on `refs/heads/stable`, but the repo only has `main` — every push silently skipped the release step.
- Retarget the condition and the version-bump push at `main` so merges into `main` actually publish to PyPI and cut a GitHub release.

## Test plan
- [ ] Merge this PR and confirm the `publish` job runs (instead of being skipped) on the resulting push to `main`.
- [ ] Verify the version bump commit + tag land on `main` and the new release appears on PyPI / GitHub Releases.