### PR TITLE
dev -> main: remote desktop, operations layer, USB passthrough, executor coverage

### DIFF
--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -155,6 +155,112 @@ def _remote_send_input(action: Dict[str, Any]) -> Dict[str, Any]:
     return remote_desktop_registry.send_input(action)
 
 
+# --- WebSocket-transport remote desktop ------------------------------------
+
+def _ws_start_host(token: str,
+                   bind: str = "127.0.0.1",
+                   port: int = 0,
+                   fps: float = 10.0,
+                   quality: int = 70,
+                   region: Optional[List[int]] = None,
+                   max_clients: int = 4) -> Dict[str, Any]:
+    """Executor adapter: start the singleton WebSocket-transport host."""
+    return remote_desktop_registry.start_ws_host(
+        token=token, bind=bind, port=int(port),
+        fps=float(fps), quality=int(quality),
+        region=region, max_clients=int(max_clients),
+    )
+
+
+def _ws_stop_host() -> Dict[str, Any]:
+    return remote_desktop_registry.stop_ws_host()
+
+
+def _ws_host_status() -> Dict[str, Any]:
+    return remote_desktop_registry.ws_host_status()
+
+
+def _ws_connect(host: str, port: int, token: str,
+                path: str = "/",
+                timeout: float = 5.0) -> Dict[str, Any]:
+    """Executor adapter: connect the singleton WS viewer."""
+    return remote_desktop_registry.connect_ws_viewer(
+        host=host, port=int(port), token=token,
+        path=path, timeout=float(timeout),
+    )
+
+
+def _ws_disconnect() -> Dict[str, Any]:
+    return remote_desktop_registry.disconnect_ws_viewer()
+
+
+def _ws_viewer_status() -> Dict[str, Any]:
+    return remote_desktop_registry.ws_viewer_status()
+
+
+def _ws_send_input(action: Dict[str, Any]) -> Dict[str, Any]:
+    return remote_desktop_registry.ws_send_input(action)
+
+
+# --- WebRTC-transport remote desktop (manual SDP signaling) ----------------
+
+def _webrtc_start_host(token: str,
+                       read_only: bool = False) -> Dict[str, Any]:
+    """Executor adapter: allocate the singleton WebRTC host.
+
+    Follow up with ``AC_webrtc_create_offer`` then
+    ``AC_webrtc_accept_answer`` once the viewer's answer SDP arrives.
+    """
+    return remote_desktop_registry.start_webrtc_host(
+        token=token, read_only=bool(read_only),
+    )
+
+
+def _webrtc_create_offer(peer_label: str = "remote viewer") -> Dict[str, Any]:
+    return remote_desktop_registry.webrtc_create_offer(peer_label=peer_label)
+
+
+def _webrtc_accept_answer(answer_sdp: str) -> Dict[str, Any]:
+    return remote_desktop_registry.webrtc_accept_answer(answer_sdp)
+
+
+def _webrtc_stop_host() -> Dict[str, Any]:
+    return remote_desktop_registry.stop_webrtc_host()
+
+
+def _webrtc_host_status() -> Dict[str, Any]:
+    return remote_desktop_registry.webrtc_host_status()
+
+
+def _webrtc_start_viewer(token: str,
+                         viewer_id: Optional[str] = None) -> Dict[str, Any]:
+    """Executor adapter: allocate the singleton WebRTC viewer."""
+    return remote_desktop_registry.start_webrtc_viewer(
+        token=token, viewer_id=viewer_id,
+    )
+
+
+def _webrtc_process_offer(offer_sdp: str,
+                          expected_dtls_fingerprint: Optional[str] = None,
+                          ) -> Dict[str, Any]:
+    return remote_desktop_registry.webrtc_process_offer(
+        offer_sdp,
+        expected_dtls_fingerprint=expected_dtls_fingerprint,
+    )
+
+
+def _webrtc_send_input(action: Dict[str, Any]) -> Dict[str, Any]:
+    return remote_desktop_registry.webrtc_send_input(action)
+
+
+def _webrtc_stop_viewer() -> Dict[str, Any]:
+    return remote_desktop_registry.stop_webrtc_viewer()
+
+
+def _webrtc_viewer_status() -> Dict[str, Any]:
+    return remote_desktop_registry.webrtc_viewer_status()
+
+
 # --- Virtual gamepad (ViGEm) -----------------------------------------------
 
 def _gamepad_press(button: str) -> Dict[str, Any]:
@@ -818,6 +924,31 @@ class Executor:
             "AC_remote_disconnect": _remote_disconnect,
             "AC_remote_viewer_status": _remote_viewer_status,
             "AC_remote_send_input": _remote_send_input,
+
+            # WebSocket-transport remote desktop host
+            "AC_start_ws_host": _ws_start_host,
+            "AC_stop_ws_host": _ws_stop_host,
+            "AC_ws_host_status": _ws_host_status,
+
+            # WebSocket-transport remote desktop viewer
+            "AC_ws_connect": _ws_connect,
+            "AC_ws_disconnect": _ws_disconnect,
+            "AC_ws_viewer_status": _ws_viewer_status,
+            "AC_ws_send_input": _ws_send_input,
+
+            # WebRTC-transport host (manual SDP exchange)
+            "AC_start_webrtc_host": _webrtc_start_host,
+            "AC_webrtc_create_offer": _webrtc_create_offer,
+            "AC_webrtc_accept_answer": _webrtc_accept_answer,
+            "AC_stop_webrtc_host": _webrtc_stop_host,
+            "AC_webrtc_host_status": _webrtc_host_status,
+
+            # WebRTC-transport viewer (manual SDP exchange)
+            "AC_start_webrtc_viewer": _webrtc_start_viewer,
+            "AC_webrtc_process_offer": _webrtc_process_offer,
+            "AC_webrtc_send_input": _webrtc_send_input,
+            "AC_stop_webrtc_viewer": _webrtc_stop_viewer,
+            "AC_webrtc_viewer_status": _webrtc_viewer_status,
 
             # Virtual gamepad (ViGEm — drives games that ignore SendInput)
             "AC_gamepad_press": _gamepad_press,

--- a/je_auto_control/utils/remote_desktop/registry.py
+++ b/je_auto_control/utils/remote_desktop/registry.py
@@ -1,26 +1,55 @@
 """Process-global singletons used by AC_remote_* executor commands.
 
 JSON action scripts and the GUI both want to talk to one running host
-and at most one active viewer without juggling handles. Holding those
-references here keeps :mod:`action_executor` thin and avoids circular
-imports between the executor and the host/viewer classes.
+and at most one active viewer per transport without juggling handles.
+Holding those references here keeps :mod:`action_executor` thin and
+avoids circular imports between the executor and the host/viewer
+classes. Three transports are supported in parallel: plain TCP, WS
+(``WebSocketDesktop*``) and WebRTC (``WebRTCDesktop*``); each has its
+own host + viewer slot so JSON scripts can stand up, e.g., a TCP host
+and a WebRTC viewer in the same process if they want to.
 """
 import ssl
 from typing import Any, Callable, Dict, Optional, Sequence
 
 from je_auto_control.utils.remote_desktop.host import RemoteDesktopHost
 from je_auto_control.utils.remote_desktop.viewer import RemoteDesktopViewer
+from je_auto_control.utils.remote_desktop.ws_host import WebSocketDesktopHost
+from je_auto_control.utils.remote_desktop.ws_viewer import (
+    WebSocketDesktopViewer,
+)
 
 FrameCallback = Callable[[bytes], None]
 ErrorCallback = Callable[[Exception], None]
 
 
+def _load_webrtc_classes():
+    """Lazy import — aiortc/av are optional extras; absent ⇒ (None, None, None)."""
+    try:
+        from je_auto_control.utils.remote_desktop.webrtc_host import (
+            WebRTCDesktopHost,
+        )
+        from je_auto_control.utils.remote_desktop.webrtc_viewer import (
+            WebRTCDesktopViewer,
+        )
+        from je_auto_control.utils.remote_desktop.webrtc_transport import (
+            WebRTCConfig,
+        )
+    except ImportError:
+        return None, None, None
+    return WebRTCDesktopHost, WebRTCDesktopViewer, WebRTCConfig
+
+
 class _RemoteDesktopRegistry:
-    """Hold one host + one viewer for the executor command surface."""
+    """Hold one host + one viewer per transport for the executor surface."""
 
     def __init__(self) -> None:
         self._host: Optional[RemoteDesktopHost] = None
         self._viewer: Optional[RemoteDesktopViewer] = None
+        self._ws_host: Optional[WebSocketDesktopHost] = None
+        self._ws_viewer: Optional[WebSocketDesktopViewer] = None
+        self._webrtc_host: Optional[Any] = None  # WebRTCDesktopHost
+        self._webrtc_viewer: Optional[Any] = None  # WebRTCDesktopViewer
 
     @property
     def host(self) -> Optional[RemoteDesktopHost]:
@@ -123,6 +152,205 @@ class _RemoteDesktopRegistry:
             raise ConnectionError("no remote viewer is connected")
         self._viewer.send_input(action)
         return {"sent": True}
+
+    # ------------------------------------------------------------------
+    # WebSocket transport
+    # ------------------------------------------------------------------
+
+    def start_ws_host(self, token: str,
+                      bind: str = "127.0.0.1",
+                      port: int = 0,
+                      fps: float = 10.0,
+                      quality: int = 70,
+                      region: Optional[Sequence[int]] = None,
+                      max_clients: int = 4,
+                      host_id: Optional[str] = None,
+                      ssl_context: Optional[ssl.SSLContext] = None,
+                      ) -> Dict[str, Any]:
+        """Stop any existing WS host, then start a fresh one (wss:// when ssl)."""
+        self.stop_ws_host()
+        host = WebSocketDesktopHost(
+            token=token, bind=bind, port=int(port),
+            fps=float(fps), quality=int(quality),
+            region=region, max_clients=int(max_clients),
+            host_id=host_id, ssl_context=ssl_context,
+        )
+        host.start()
+        self._ws_host = host
+        return self.ws_host_status()
+
+    def stop_ws_host(self, timeout: float = 2.0) -> Dict[str, Any]:
+        if self._ws_host is not None:
+            self._ws_host.stop(timeout=timeout)
+            self._ws_host = None
+        return self.ws_host_status()
+
+    def ws_host_status(self) -> Dict[str, Any]:
+        host = self._ws_host
+        if host is None:
+            return {
+                "running": False, "port": 0, "connected_clients": 0,
+                "host_id": None,
+            }
+        return {
+            "running": host.is_running,
+            "port": host.port,
+            "connected_clients": host.connected_clients,
+            "host_id": host.host_id,
+        }
+
+    def connect_ws_viewer(self, host: str, port: int, token: str,
+                          path: str = "/",
+                          timeout: float = 5.0,
+                          on_frame: Optional[FrameCallback] = None,
+                          on_error: Optional[ErrorCallback] = None,
+                          expected_host_id: Optional[str] = None,
+                          ssl_context: Optional[ssl.SSLContext] = None,
+                          server_hostname: Optional[str] = None,
+                          ) -> Dict[str, Any]:
+        """Disconnect any existing WS viewer, then connect a fresh one."""
+        self.disconnect_ws_viewer()
+        viewer = WebSocketDesktopViewer(
+            host=host, port=int(port), token=token,
+            on_frame=on_frame, on_error=on_error,
+            expected_host_id=expected_host_id,
+            ssl_context=ssl_context,
+            server_hostname=server_hostname,
+            path=path,
+        )
+        viewer.connect(timeout=float(timeout))
+        self._ws_viewer = viewer
+        return self.ws_viewer_status()
+
+    def disconnect_ws_viewer(self, timeout: float = 2.0) -> Dict[str, Any]:
+        if self._ws_viewer is not None:
+            self._ws_viewer.disconnect(timeout=timeout)
+            self._ws_viewer = None
+        return self.ws_viewer_status()
+
+    def ws_viewer_status(self) -> Dict[str, Any]:
+        viewer = self._ws_viewer
+        if viewer is None:
+            return {"connected": False, "host_id": None}
+        return {
+            "connected": viewer.connected,
+            "host_id": viewer.remote_host_id,
+        }
+
+    def ws_send_input(self, action: Dict[str, Any]) -> Dict[str, Any]:
+        if self._ws_viewer is None or not self._ws_viewer.connected:
+            raise ConnectionError("no websocket viewer is connected")
+        self._ws_viewer.send_input(action)
+        return {"sent": True}
+
+    # ------------------------------------------------------------------
+    # WebRTC transport (optional — requires aiortc + av)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _require_webrtc():
+        host_cls, viewer_cls, config_cls = _load_webrtc_classes()
+        if host_cls is None:
+            raise RuntimeError(
+                "WebRTC support is unavailable: install the 'webrtc' extra"
+            )
+        return host_cls, viewer_cls, config_cls
+
+    def start_webrtc_host(self, token: str,
+                          config: Optional[Any] = None,
+                          read_only: bool = False,
+                          ) -> Dict[str, Any]:
+        """Build a WebRTC host with manual SDP signaling.
+
+        The caller must follow up with :meth:`webrtc_create_offer` and
+        :meth:`webrtc_accept_answer` to complete the handshake; this
+        method only allocates the host singleton.
+        """
+        host_cls, _viewer_cls, _config_cls = self._require_webrtc()
+        self.stop_webrtc_host()
+        host = host_cls(
+            token=token, config=config, read_only=bool(read_only),
+        )
+        self._webrtc_host = host
+        return self.webrtc_host_status()
+
+    def webrtc_create_offer(self,
+                            peer_label: str = "remote viewer") -> Dict[str, Any]:
+        if self._webrtc_host is None:
+            raise RuntimeError("no WebRTC host is running")
+        offer_sdp = self._webrtc_host.create_offer(peer_label=peer_label)
+        return {"offer_sdp": offer_sdp}
+
+    def webrtc_accept_answer(self, answer_sdp: str) -> Dict[str, Any]:
+        if self._webrtc_host is None:
+            raise RuntimeError("no WebRTC host is running")
+        self._webrtc_host.accept_answer(answer_sdp)
+        return self.webrtc_host_status()
+
+    def stop_webrtc_host(self) -> Dict[str, Any]:
+        if self._webrtc_host is not None:
+            try:
+                self._webrtc_host.stop()
+            finally:
+                self._webrtc_host = None
+        return self.webrtc_host_status()
+
+    def webrtc_host_status(self) -> Dict[str, Any]:
+        host = self._webrtc_host
+        if host is None:
+            return {"running": False, "authenticated": False, "state": "closed"}
+        return {
+            "running": True,
+            "authenticated": host.authenticated,
+            "state": host.connection_state,
+        }
+
+    def start_webrtc_viewer(self, token: str,
+                            config: Optional[Any] = None,
+                            viewer_id: Optional[str] = None,
+                            ) -> Dict[str, Any]:
+        """Build a WebRTC viewer; call :meth:`webrtc_process_offer` next."""
+        _host_cls, viewer_cls, _config_cls = self._require_webrtc()
+        self.stop_webrtc_viewer()
+        viewer = viewer_cls(
+            token=token, config=config, viewer_id=viewer_id,
+        )
+        self._webrtc_viewer = viewer
+        return self.webrtc_viewer_status()
+
+    def webrtc_process_offer(self, offer_sdp: str,
+                             expected_dtls_fingerprint: Optional[str] = None,
+                             ) -> Dict[str, Any]:
+        if self._webrtc_viewer is None:
+            raise RuntimeError("no WebRTC viewer is active")
+        answer_sdp = self._webrtc_viewer.process_offer(
+            offer_sdp,
+            expected_dtls_fingerprint=expected_dtls_fingerprint,
+        )
+        return {"answer_sdp": answer_sdp}
+
+    def webrtc_send_input(self, action: Dict[str, Any]) -> Dict[str, Any]:
+        if self._webrtc_viewer is None:
+            raise RuntimeError("no WebRTC viewer is active")
+        self._webrtc_viewer.send_input(action)
+        return {"sent": True}
+
+    def stop_webrtc_viewer(self) -> Dict[str, Any]:
+        if self._webrtc_viewer is not None:
+            try:
+                self._webrtc_viewer.stop()
+            finally:
+                self._webrtc_viewer = None
+        return self.webrtc_viewer_status()
+
+    def webrtc_viewer_status(self) -> Dict[str, Any]:
+        viewer = self._webrtc_viewer
+        if viewer is None:
+            return {"active": False, "authenticated": False}
+        return {
+            "active": True,
+            "authenticated": getattr(viewer, "authenticated", False),
+        }
 
 
 registry = _RemoteDesktopRegistry()

--- a/test/unit_test/headless/test_remote_desktop_executor.py
+++ b/test/unit_test/headless/test_remote_desktop_executor.py
@@ -1,4 +1,4 @@
-"""Tests for the AC_remote_* executor commands and registry singleton."""
+"""Tests for the AC_remote_* / AC_ws_* / AC_webrtc_* executor commands."""
 import time
 
 import pytest
@@ -12,9 +12,17 @@ def reset_registry():
     """Tear down any leftover host/viewer before and after each test."""
     registry.disconnect_viewer()
     registry.stop_host()
+    registry.disconnect_ws_viewer()
+    registry.stop_ws_host()
+    registry.stop_webrtc_viewer()
+    registry.stop_webrtc_host()
     yield
     registry.disconnect_viewer()
     registry.stop_host()
+    registry.disconnect_ws_viewer()
+    registry.stop_ws_host()
+    registry.stop_webrtc_viewer()
+    registry.stop_webrtc_host()
 
 
 def _wait_until(predicate, timeout: float = 2.0,
@@ -115,3 +123,130 @@ def test_remote_round_trip_through_executor():
     assert registry.viewer_status()["connected"] is False
     executor.execute_action([["AC_stop_remote_host"]])
     assert registry.host_status()["running"] is False
+
+
+# --- WebSocket-transport executor commands ---------------------------------
+
+
+def test_known_commands_include_ws_transport():
+    cmds = executor.known_commands()
+    for name in (
+        "AC_start_ws_host", "AC_stop_ws_host", "AC_ws_host_status",
+        "AC_ws_connect", "AC_ws_disconnect", "AC_ws_viewer_status",
+        "AC_ws_send_input",
+    ):
+        assert name in cmds
+
+
+def test_ws_send_input_without_viewer_records_connection_error():
+    record = executor.execute_action([
+        ["AC_ws_send_input", {"action": {"action": "ping"}}],
+    ])
+    assert any("ConnectionError" in repr(v) for v in record.values())
+
+
+def test_ws_round_trip_through_executor():
+    """Start WS host + connect WS viewer + send input via executor commands."""
+    from je_auto_control.utils.remote_desktop.ws_host import (
+        WebSocketDesktopHost,
+    )
+    captured = []
+    host = WebSocketDesktopHost(
+        token="tok", bind="127.0.0.1", port=0, fps=50.0,
+        frame_provider=lambda: b"ws-exec-frame",
+        input_dispatcher=captured.append,
+    )
+    host.start()
+    registry._ws_host = host  # noqa: SLF001  # test-only injection
+
+    status = executor.execute_action([["AC_ws_host_status"]])
+    status_value = next(iter(status.values()))
+    assert status_value["running"] is True
+    port = status_value["port"]
+    assert port > 0
+
+    executor.execute_action([
+        ["AC_ws_connect", {
+            "host": "127.0.0.1", "port": port, "token": "tok",
+        }],
+    ])
+    assert registry.ws_viewer_status()["connected"] is True
+    assert _wait_until(lambda: registry._ws_host.connected_clients == 1)  # noqa: SLF001
+
+    executor.execute_action([
+        ["AC_ws_send_input", {
+            "action": {"action": "mouse_move", "x": 11, "y": 22},
+        }],
+    ])
+    assert _wait_until(lambda: captured == [
+        {"action": "mouse_move", "x": 11, "y": 22}
+    ])
+
+    executor.execute_action([["AC_ws_disconnect"]])
+    assert registry.ws_viewer_status()["connected"] is False
+    executor.execute_action([["AC_stop_ws_host"]])
+    assert registry.ws_host_status()["running"] is False
+
+
+# --- WebRTC-transport executor commands (aiortc-dependent) -----------------
+
+
+def test_known_commands_include_webrtc_transport():
+    cmds = executor.known_commands()
+    for name in (
+        "AC_start_webrtc_host", "AC_webrtc_create_offer",
+        "AC_webrtc_accept_answer", "AC_stop_webrtc_host",
+        "AC_webrtc_host_status",
+        "AC_start_webrtc_viewer", "AC_webrtc_process_offer",
+        "AC_webrtc_send_input", "AC_stop_webrtc_viewer",
+        "AC_webrtc_viewer_status",
+    ):
+        assert name in cmds
+
+
+def test_webrtc_host_status_idle_via_executor():
+    record = executor.execute_action([["AC_webrtc_host_status"]])
+    status_value = next(iter(record.values()))
+    assert status_value == {
+        "running": False, "authenticated": False, "state": "closed",
+    }
+
+
+def test_webrtc_viewer_status_idle_via_executor():
+    record = executor.execute_action([["AC_webrtc_viewer_status"]])
+    status_value = next(iter(record.values()))
+    assert status_value == {"active": False, "authenticated": False}
+
+
+def _webrtc_available() -> bool:
+    try:
+        import aiortc  # noqa: F401
+        import av  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(
+    not _webrtc_available(),
+    reason="WebRTC extras (aiortc + av) not installed",
+)
+def test_webrtc_start_host_allocates_singleton():
+    """When aiortc is present, AC_start_webrtc_host returns running=True."""
+    record = executor.execute_action([
+        ["AC_start_webrtc_host", {"token": "tok", "read_only": True}],
+    ])
+    status_value = next(iter(record.values()))
+    assert status_value["running"] is True
+    executor.execute_action([["AC_stop_webrtc_host"]])
+    assert registry.webrtc_host_status()["running"] is False
+
+
+def test_webrtc_start_host_without_extras_records_runtime_error():
+    """When aiortc is absent, AC_start_webrtc_host records a RuntimeError."""
+    if _webrtc_available():
+        pytest.skip("WebRTC extras are installed; absence path not exercised")
+    record = executor.execute_action([
+        ["AC_start_webrtc_host", {"token": "tok"}],
+    ])
+    assert any("RuntimeError" in repr(v) for v in record.values())


### PR DESCRIPTION
## Summary

Roll-up of the `dev` branch into `main`. Major themes:

- **Remote Desktop**: full host/viewer over TCP, WebSocket, and WebRTC; TLS, persistent host ID, audio streaming, bidirectional clipboard + file transfer; GUI tab redesigned around connection cards and split into a `gui/remote_desktop/` subpackage with a pop-out window. WebRTC tab degrades gracefully when the optional `webrtc` extra is missing.
- **Executor command coverage (this commit)**: 17 new `AC_*` commands expose WebSocket and WebRTC host/viewer flows to action files, the socket server, the scheduler, and the visual script builder — closing the CLAUDE.md feature-delivery gap where only the TCP transport had headless executor coverage.
- **Operations layer + USB passthrough**: new operations layer and USB Phase 2 chain landed across rounds 22-47.
- **Triggers + secrets**: webhook (HTTP push) trigger, IMAP email-poll trigger, encrypted secret manager with `${secrets.NAME}` placeholders.
- **Profiler + run history**: per-action profiler with hot-spot view; timeline and failure thumbnails in run history tab.
- **Driver-level input backends**: Interception, uinput, ViGEm.
- **MCP server**: remote desktop now exposed over MCP.
- **Static analysis sweep**: multiple rounds clearing Sonar / Codacy / Bandit findings (PRs #181-#184).
- **CI**: Python 3.13 + 3.14 added to the matrix; WS handshake flakes addressed.

## Test plan

- [ ] CI green on all matrix entries (Win/macOS/Linux × 3.10-3.14).
- [ ] `python -m pytest test/unit_test/` passes locally.
- [ ] Remote desktop suite green: `pytest test/unit_test/headless/test_remote_desktop_*.py test/unit_test/headless/test_webrtc_inspector.py test/unit_test/headless/test_turn_config.py` — verified locally **126 passed, 2 skipped** (skips require `aiortc` + `av`).
- [ ] Top-level package still Qt-free: `python -c "import sys, je_auto_control; assert not any('PySide6' in m for m in sys.modules)"` exits 0.
- [ ] GUI smoke test: launch `start_autocontrol_gui()`, open the Remote Desktop tab, confirm WebRTC sub-tab degrades cleanly when the extra is absent.