### PR TITLE
Bump quality tooling: ruff 0.15.13, pytest 9.0.3, PySide6 6.11.1

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -81,7 +81,7 @@ jobs:
           # for any sub-package the snapshot doesn't include
           # (admin, usb, remote_desktop, vision, …).
           pip install -e .
-          pip install ruff==0.15.9 bandit==1.9.4 pytest==9.0.2 pytest-timeout==2.4.0 pytest-rerunfailures==15.1 PySide6==6.11.0
+          pip install ruff==0.15.13 bandit==1.9.4 pytest==9.0.3 pytest-timeout==2.4.0 pytest-rerunfailures==15.1 PySide6==6.11.1
 
       - name: Run headless pytest suite
         run: pytest test/unit_test/headless/ -v --tb=short --timeout=120

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,13 +4,13 @@ build
 twine
 sphinx
 sphinx-rtd-theme
-PySide6==6.11.0
+PySide6==6.11.1
 qt-material==2.17
 mss==10.2.0
 defusedxml==0.7.1
 
 # Quality tooling — used by .github/workflows/quality.yml and locally.
-ruff==0.15.9
+ruff==0.15.13
 bandit==1.9.4
-pytest==9.0.2
+pytest==9.0.3
 pytest-timeout==2.4.0


### PR DESCRIPTION
## Summary

Patch-level bumps for the dev/CI toolchain pinned in `dev_requirements.txt` and `.github/workflows/quality.yml`:

| Package | From | To |
|---|---|---|
| ruff | 0.15.9 | 0.15.13 |
| pytest | 9.0.2 | 9.0.3 |
| PySide6 | 6.11.0 | 6.11.1 |

## Test plan

- [x] `ruff check je_auto_control/` — clean on 0.15.13.
- [x] `pytest test/unit_test/headless/` — 668 passed, 11 skipped on 9.0.3 + PySide6 6.11.1.
- [ ] CI green across the full Windows × (3.10–3.14) matrix.