### PR TITLE
Fix flaky remote-desktop socket tests (handshake timeout deadlock)

### DIFF
--- a/je_auto_control/utils/remote_desktop/viewer.py
+++ b/je_auto_control/utils/remote_desktop/viewer.py
@@ -31,7 +31,6 @@ ViewerCursorCallback = Callable[[str, int, int], None]
 ChatCallback = Callable[[str, str], None]
 ErrorCallback = Callable[[Exception], None]
 
-_DEFAULT_AUTH_TIMEOUT_S = 60.0
 _DEFAULT_CONNECT_TIMEOUT_S = 5.0
 _NOT_CONNECTED_MESSAGE = "viewer is not connected"
 
@@ -190,11 +189,13 @@ class RemoteDesktopViewer:
         raw_sock = socket.create_connection(
             (self._host, self._port), timeout=timeout,
         )
-        # If the caller explicitly asked for a longer connect budget,
-        # honor it for the handshake too — otherwise a slow remote (CI
-        # runners, high-latency links) trips the 5 s default before the
-        # caller's window expires.
-        raw_sock.settimeout(max(_DEFAULT_AUTH_TIMEOUT_S, float(timeout)))
+        # Bound the auth handshake by the caller's timeout. A short, explicit
+        # timeout must be honored — e.g. a plain viewer hitting a TLS host has
+        # to fail fast instead of blocking on a handshake that never
+        # completes. The handshake is a tiny HMAC exchange, so the connect
+        # budget is ample; callers needing longer simply pass a larger
+        # timeout.
+        raw_sock.settimeout(float(timeout))
         try:
             sock = self._maybe_wrap_tls(raw_sock)
             channel = self._build_channel(sock)

--- a/test/unit_test/headless/test_remote_desktop_websocket.py
+++ b/test/unit_test/headless/test_remote_desktop_websocket.py
@@ -242,7 +242,7 @@ def test_plain_tcp_viewer_against_ws_host_is_rejected():
             host="127.0.0.1", port=host.port, token="tok",
         )
         with pytest.raises((OSError, AuthenticationError)):
-            viewer.connect(timeout=30.0)
+            viewer.connect(timeout=2.0)
         assert _wait_until(lambda: host.connected_clients == 0)
     finally:
         host.stop(timeout=1.0)


### PR DESCRIPTION
## Problem

Two tests intermittently hung the whole headless suite (pytest-timeout
hard-kills the process, so a single hang fails the run):

- `test_remote_desktop_tls.py::test_plain_viewer_against_tls_host_fails`
- `test_remote_desktop_websocket.py::test_plain_tcp_viewer_against_ws_host_is_rejected`

## Root cause

`RemoteDesktopViewer.connect(timeout=...)` set the auth-handshake socket
timeout to `max(_DEFAULT_AUTH_TIMEOUT_S=60, timeout)`, so an explicit
short timeout (the tests pass 2s / 30s to detect a protocol mismatch) was
floored to 60s. A plain viewer connecting to a TLS/WS host then blocked
~60s on a handshake that never completes — the same 60s as the test
timeout, so it raced and intermittently hung.

## Fix

- Bound the handshake by the caller's `timeout` (the handshake is a tiny
  HMAC exchange; the connect budget is ample, and callers needing more
  pass a larger timeout). Removes the unused auth-timeout constant.
- Tighten the WebSocket rejection test to a 2s budget.

Both mismatch tests now fail fast and deterministically (~2s each, was a
60s race). Full `test_remote_desktop_tls.py` + `test_remote_desktop_websocket.py`
pass in ~6s.
