### PR TITLE
Add rotation- and scale-tolerant template matching

### DIFF
--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 旋转与缩放容忍的模板匹配
+
+不只缩放,还能找到旋转或倾斜的模板。完整参考:[`docs/source/Zh/doc/new_features/v158_features_doc.rst`](../docs/source/Zh/doc/new_features/v158_features_doc.rst)。
+
+- **`match_rotated` / `match_rotated_all` / `scale_space`**(`AC_match_rotated`、`AC_match_rotated_all`):`match_template` 只扫描*缩放*且假设轴对齐——OpenCV 的 `matchTemplate` 不具旋转不变性,因此倾斜的控件、旋转的图标,或转到不同角度的刻度盘都会匹配失败。本功能扫描 `angles`(每个以 `cv2.warpAffine` 变形)并与 `np.linspace` 缩放空间交叉,返回相关性最高、且带有还原 `scale` + `angle` 的 `RotatedMatch`(`*_all` 版本以 NMS 合并相邻角度 / 缩放)。重用 `visual_match` 的加载器 / resize / 方法表 / NMS——不重复任何匹配或几何代码。`haystack` 可注入;可无头测试;不导入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 一维条码解码
 
 从屏幕或图像读取 EAN / UPC / Code-128 条码。完整参考:[`docs/source/Zh/doc/new_features/v157_features_doc.rst`](../docs/source/Zh/doc/new_features/v157_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 旋轉與縮放容忍的樣板比對
+
+不只縮放,還能找到旋轉或傾斜的樣板。完整參考:[`docs/source/Zh/doc/new_features/v158_features_doc.rst`](../docs/source/Zh/doc/new_features/v158_features_doc.rst)。
+
+- **`match_rotated` / `match_rotated_all` / `scale_space`**(`AC_match_rotated`、`AC_match_rotated_all`):`match_template` 只掃描*縮放*且假設軸對齊——OpenCV 的 `matchTemplate` 不具旋轉不變性,因此傾斜的控制項、旋轉的圖示,或轉到不同角度的刻度盤都會比對失敗。本功能掃描 `angles`(每個以 `cv2.warpAffine` 變形)並與 `np.linspace` 縮放空間交叉,回傳相關性最高、且帶有還原 `scale` + `angle` 的 `RotatedMatch`(`*_all` 版本以 NMS 合併相鄰角度 / 縮放)。重用 `visual_match` 的載入器 / resize / 方法表 / NMS——不重複任何比對或幾何程式。`haystack` 可注入;可無頭測試;不匯入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 一維條碼解碼
 
 從螢幕或影像讀取 EAN / UPC / Code-128 條碼。完整參考:[`docs/source/Zh/doc/new_features/v157_features_doc.rst`](../docs/source/Zh/doc/new_features/v157_features_doc.rst)。

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Rotation- & Scale-Tolerant Template Matching
+
+Find templates that are rotated or skewed, not just scaled. Full reference: [`docs/source/Eng/doc/new_features/v158_features_doc.rst`](docs/source/Eng/doc/new_features/v158_features_doc.rst).
+
+- **`match_rotated` / `match_rotated_all` / `scale_space`** (`AC_match_rotated`, `AC_match_rotated_all`): `match_template` sweeps *scales* but assumes axis-aligned — OpenCV's `matchTemplate` isn't rotation-invariant, so a skewed control, a rotated icon or a dial at a different angle is missed. This sweeps `angles` (each warped with `cv2.warpAffine`) crossed with a `np.linspace` scale-space, returns the best-correlating `RotatedMatch` carrying the recovered `scale` + `angle` (the `*_all` form NMS-dedupes neighbouring angles/scales). Reuses `visual_match`'s loaders / resize / method table / NMS — no matching or geometry code duplicated. Injectable `haystack`; headless-testable; no `PySide6`.
+
 ## What's new (2026-06-23) — Barcode Decoding (1-D)
 
 Read EAN / UPC / Code-128 barcodes off the screen or an image. Full reference: [`docs/source/Eng/doc/new_features/v157_features_doc.rst`](docs/source/Eng/doc/new_features/v157_features_doc.rst).

--- a/docs/source/Eng/doc/new_features/v158_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v158_features_doc.rst
@@ -1,0 +1,49 @@
+Rotation- and Scale-Tolerant Template Matching
+==============================================
+
+``match_template`` searches a template across *scales* (DPI / zoom tolerance) but
+assumes it is axis-aligned — OpenCV's ``matchTemplate`` is not rotation-invariant,
+so a control rendered at a slight skew, a rotated icon, or a dial/knob at a different
+angle is missed. ``match_rotated`` adds a rotation sweep: each angle is applied to
+the template with ``cv2.warpAffine``, crossed with a ``np.linspace`` scale-space, and
+the best-correlating (scale, angle) is returned — so the caller also learns the
+recovered *pose*.
+
+It reuses ``visual_match``'s grayscale loaders, scale resize, correlation-method
+table and non-maximum suppression, so no matching or geometry code is duplicated.
+The ``haystack`` is injectable (ndarray / path / PIL), so the search is unit-testable
+on synthetic arrays; only the default (grab the screen) is device-bound. Imports no
+``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import match_rotated, match_rotated_all, scale_space
+
+    # find a knob that may be turned to any of these angles, at any of these scales
+    hit = match_rotated("knob.png", angles=[-15, 0, 15, 30],
+                        scales=scale_space(0.9, 1.1, 3), min_score=0.85)
+    if hit:
+        print(hit.angle, hit.scale, hit.score, hit.center)
+
+    # every rotated occurrence, overlaps merged by NMS
+    for m in match_rotated_all("arrow.png", angles=[0, 90, 180, 270]):
+        print(m.center, m.angle)
+
+``match_rotated`` returns a single ``RotatedMatch`` (``x`` / ``y`` / ``width`` /
+``height`` / ``score`` / ``scale`` / ``angle`` + ``center``) or ``None``;
+``match_rotated_all`` returns every hit at or above ``min_score`` with overlapping
+detections from neighbouring angles / scales collapsed by NMS, ordered by score.
+``scale_space(min, max, steps)`` is a helper returning evenly spaced scales.
+
+Executor commands
+-----------------
+
+``AC_match_rotated`` (``template`` / ``min_score`` / ``angles`` / ``scales`` /
+``region`` / ``method`` → ``{found, match}``) and ``AC_match_rotated_all`` (adds
+``max_results`` / ``nms_iou`` → ``{count, matches}``). They are exposed as the MCP
+tools ``ac_match_rotated`` / ``ac_match_rotated_all`` (read-only) and as Script
+Builder commands **Match Template (rotated)** / **Match Template All (rotated)**
+under **Image**.

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -180,6 +180,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v155_features_doc
    doc/new_features/v156_features_doc
    doc/new_features/v157_features_doc
+   doc/new_features/v158_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/doc/new_features/v158_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v158_features_doc.rst
@@ -1,0 +1,44 @@
+旋轉與縮放容忍的樣板比對
+========================
+
+``match_template`` 能跨*縮放*搜尋樣板(容忍 DPI / 縮放),但假設樣板為軸對齊——
+OpenCV 的 ``matchTemplate`` 不具旋轉不變性,因此略為傾斜的控制項、旋轉的圖示,或
+轉到不同角度的旋鈕 / 刻度盤都會比對失敗。``match_rotated`` 加入旋轉掃描:每個角度
+以 ``cv2.warpAffine`` 套用到樣板上,並與 ``np.linspace`` 縮放空間交叉,回傳相關性
+最高的(scale, angle)——因此呼叫端也能得知還原出的*姿態*。
+
+本功能重用 ``visual_match`` 的灰階載入器、縮放 resize、相關性方法表與非極大值抑制,
+不重複任何比對或幾何程式。``haystack`` 可注入(ndarray / 路徑 / PIL),因此搜尋可在
+合成陣列上單元測試;只有預設(擷取螢幕)為裝置相依。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import match_rotated, match_rotated_all, scale_space
+
+    # 尋找可能轉到任一角度、任一縮放的旋鈕
+    hit = match_rotated("knob.png", angles=[-15, 0, 15, 30],
+                        scales=scale_space(0.9, 1.1, 3), min_score=0.85)
+    if hit:
+        print(hit.angle, hit.scale, hit.score, hit.center)
+
+    # 每個旋轉後的出現位置,重疊以 NMS 合併
+    for m in match_rotated_all("arrow.png", angles=[0, 90, 180, 270]):
+        print(m.center, m.angle)
+
+``match_rotated`` 回傳單一 ``RotatedMatch``(``x`` / ``y`` / ``width`` / ``height`` /
+``score`` / ``scale`` / ``angle`` + ``center``)或 ``None``;``match_rotated_all``
+回傳所有達到 ``min_score`` 的命中,相鄰角度 / 縮放的重疊偵測以 NMS 合併,依分數排序。
+``scale_space(min, max, steps)`` 為回傳等間距縮放的輔助函式。
+
+執行器指令
+----------
+
+``AC_match_rotated``(``template`` / ``min_score`` / ``angles`` / ``scales`` /
+``region`` / ``method`` → ``{found, match}``)與 ``AC_match_rotated_all``(另加
+``max_results`` / ``nms_iou`` → ``{count, matches}``)。兩者以 MCP 工具
+``ac_match_rotated`` / ``ac_match_rotated_all``(唯讀)及 Script Builder 指令
+**Match Template (rotated)** / **Match Template All (rotated)**(位於 **Image**
+分類下)形式提供。

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -180,6 +180,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v155_features_doc
    doc/new_features/v156_features_doc
    doc/new_features/v157_features_doc
+   doc/new_features/v158_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -279,6 +279,10 @@ from je_auto_control.utils.visual_match import (
     match_template_all,
 )
 from je_auto_control.utils.visual_match import Match as TemplateMatch
+# Rotation- and scale-tolerant template matching (scale-space x angle sweep)
+from je_auto_control.utils.rotated_match import (
+    RotatedMatch, match_rotated, match_rotated_all, scale_space,
+)
 # Locate on-screen regions by colour (mask + connected components)
 from je_auto_control.utils.color_region import (
     find_color_region, find_color_regions,
@@ -1182,6 +1186,10 @@ __all__ = [
     "match_masked",
     "match_masked_all",
     "best_matches",
+    "RotatedMatch",
+    "match_rotated",
+    "match_rotated_all",
+    "scale_space",
     "find_color_region",
     "find_color_regions",
     "ssim_compare",

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -305,6 +305,37 @@ def _add_image_specs(specs: List[CommandSpec]) -> None:
         description="Find every masked match of a template (NMS-deduped).",
     ))
     specs.append(CommandSpec(
+        "AC_match_rotated", "Image", "Match Template (rotated)",
+        fields=(
+            FieldSpec("template", FieldType.FILE_PATH),
+            FieldSpec("min_score", FieldType.FLOAT, optional=True, default=0.8,
+                      min_value=0.0, max_value=1.0),
+            FieldSpec("angles", FieldType.STRING, optional=True,
+                      placeholder="[-10, 0, 10]"),
+            FieldSpec("scales", FieldType.STRING, optional=True,
+                      placeholder="[0.9, 1.0, 1.1]"),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Locate a template tolerating rotation + scale; reports angle.",
+    ))
+    specs.append(CommandSpec(
+        "AC_match_rotated_all", "Image", "Match Template All (rotated)",
+        fields=(
+            FieldSpec("template", FieldType.FILE_PATH),
+            FieldSpec("min_score", FieldType.FLOAT, optional=True, default=0.8,
+                      min_value=0.0, max_value=1.0),
+            FieldSpec("angles", FieldType.STRING, optional=True,
+                      placeholder="[-10, 0, 10]"),
+            FieldSpec("scales", FieldType.STRING, optional=True,
+                      placeholder="[0.9, 1.0, 1.1]"),
+            FieldSpec("max_results", FieldType.INT, optional=True, default=20),
+            FieldSpec("nms_iou", FieldType.FLOAT, optional=True, default=0.3,
+                      min_value=0.0, max_value=1.0),
+        ),
+        description="Find every rotation/scale-tolerant match (NMS-deduped).",
+    ))
+    specs.append(CommandSpec(
         "AC_find_color_region", "Image", "Find Colour Region",
         fields=(
             FieldSpec("rgb", FieldType.STRING, placeholder="[0, 200, 0]"),

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -1,5 +1,5 @@
 import types
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from je_auto_control.utils.exception.exception_tags import (
     action_is_null_error_message, add_command_exception_error_message,
@@ -3282,6 +3282,47 @@ def _match_masked_all(template: str, mask: Any = None, min_score: Any = 0.9,
     return {"count": len(matches), "matches": [m.to_dict() for m in matches]}
 
 
+def _seq_arg(value: Any, default: Sequence[float]) -> Sequence[float]:
+    """Coerce a JSON-string / list arg into a tuple of floats, or the default."""
+    import json
+    if isinstance(value, str):
+        value = json.loads(value) if value.strip() else None
+    return tuple(float(v) for v in value) if value else tuple(default)
+
+
+def _match_rotated(template: str, min_score: Any = 0.8, scales: Any = None,
+                   angles: Any = None, region: Any = None,
+                   method: str = "ccoeff_normed") -> Dict[str, Any]:
+    """Adapter: best rotation/scale-tolerant template match on the screen."""
+    import json
+    from je_auto_control.utils.rotated_match import match_rotated
+    if isinstance(region, str):
+        region = json.loads(region) if region.strip() else None
+    match = match_rotated(template, region=region,
+                          scales=_seq_arg(scales, (1.0,)),
+                          angles=_seq_arg(angles, (0.0,)),
+                          min_score=float(min_score), method=method)
+    return {"found": match is not None,
+            "match": match.to_dict() if match else None}
+
+
+def _match_rotated_all(template: str, min_score: Any = 0.8, scales: Any = None,
+                       angles: Any = None, max_results: Any = 20,
+                       nms_iou: Any = 0.3, region: Any = None) -> Dict[str, Any]:
+    """Adapter: every rotation/scale-tolerant template match (NMS)."""
+    import json
+    from je_auto_control.utils.rotated_match import match_rotated_all
+    if isinstance(region, str):
+        region = json.loads(region) if region.strip() else None
+    matches = match_rotated_all(template, region=region,
+                                scales=_seq_arg(scales, (1.0,)),
+                                angles=_seq_arg(angles, (0.0,)),
+                                min_score=float(min_score),
+                                max_results=int(max_results),
+                                nms_iou=float(nms_iou))
+    return {"count": len(matches), "matches": [m.to_dict() for m in matches]}
+
+
 def _find_color_region(rgb: Any, tolerance: Any = 20, min_area: Any = 50,
                        region: Any = None) -> Dict[str, Any]:
     """Adapter: locate coloured regions on the screen, largest first."""
@@ -5684,6 +5725,8 @@ class Executor:
             "AC_match_template_all": _match_template_all,
             "AC_match_masked": _match_masked,
             "AC_match_masked_all": _match_masked_all,
+            "AC_match_rotated": _match_rotated,
+            "AC_match_rotated_all": _match_rotated_all,
             "AC_ssim_compare": _ssim_compare,
             "AC_ssim_changed_regions": _ssim_changed_regions,
             "AC_feature_match": _feature_match,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3538,6 +3538,46 @@ def visual_match_tools() -> List[MCPTool]:
     ]
 
 
+def rotated_match_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_match_rotated",
+            description=("Find 'template' on screen tolerating ROTATION and scale: "
+                         "sweeps 'angles' (degrees, e.g. [-10,0,10]) x 'scales', "
+                         "returns the best {found, match:{x,y,width,height,score,"
+                         "scale,angle,center}}. Use when a control is skewed / a "
+                         "rotated icon / a dial. 'min_score', 'region', 'method'."),
+            input_schema=schema({
+                "template": {"type": "string"},
+                "min_score": {"type": "number"},
+                "scales": {"type": "array", "items": {"type": "number"}},
+                "angles": {"type": "array", "items": {"type": "number"}},
+                "region": {"type": "array", "items": {"type": "integer"}},
+                "method": {"type": "string"}},
+                required=["template"]),
+            handler=h.match_rotated,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_match_rotated_all",
+            description=("Find EVERY rotation/scale-tolerant match of 'template' "
+                         ">= 'min_score' over the angle x scale sweep, overlaps "
+                         "removed by NMS. Returns {count, matches}."),
+            input_schema=schema({
+                "template": {"type": "string"},
+                "min_score": {"type": "number"},
+                "scales": {"type": "array", "items": {"type": "number"}},
+                "angles": {"type": "array", "items": {"type": "number"}},
+                "max_results": {"type": "integer"},
+                "nms_iou": {"type": "number"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["template"]),
+            handler=h.match_rotated_all,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def grid_locator_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6929,6 +6969,7 @@ ALL_FACTORIES = (
     process_doc_tools, tween_drag_tools, mouse_path_tools, field_entry_tools,
     key_hold_tools, mouse_relative_tools, text_unicode_tools,
     modifier_state_tools, grid_locator_tools, visual_match_tools,
+    rotated_match_tools,
     color_region_tools, ssim_tools, feature_match_tools, shape_locator_tools,
     window_layout_tools, window_arrange_tools, preprocess_tools,
     monitor_layout_tools, actionability_tools, element_parse_tools,

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2094,6 +2094,20 @@ def match_masked_all(template, mask=None, min_score=0.9, max_results=20,
                              region)
 
 
+def match_rotated(template, min_score=0.8, scales=None, angles=None,
+                  region=None, method="ccoeff_normed"):
+    from je_auto_control.utils.executor.action_executor import _match_rotated
+    return _match_rotated(template, min_score, scales, angles, region, method)
+
+
+def match_rotated_all(template, min_score=0.8, scales=None, angles=None,
+                      max_results=20, nms_iou=0.3, region=None):
+    from je_auto_control.utils.executor.action_executor import (
+        _match_rotated_all)
+    return _match_rotated_all(template, min_score, scales, angles, max_results,
+                              nms_iou, region)
+
+
 def find_color_region(rgb, tolerance=20, min_area=50, region=None):
     from je_auto_control.utils.executor.action_executor import (
         _find_color_region)

--- a/je_auto_control/utils/rotated_match/__init__.py
+++ b/je_auto_control/utils/rotated_match/__init__.py
@@ -1,0 +1,6 @@
+"""Rotation- and scale-tolerant template matching (scale-space x angle sweep)."""
+from je_auto_control.utils.rotated_match.rotated_match import (
+    RotatedMatch, match_rotated, match_rotated_all, scale_space,
+)
+
+__all__ = ["RotatedMatch", "match_rotated", "match_rotated_all", "scale_space"]

--- a/je_auto_control/utils/rotated_match/rotated_match.py
+++ b/je_auto_control/utils/rotated_match/rotated_match.py
@@ -1,0 +1,139 @@
+"""Rotation- and scale-tolerant template matching.
+
+``visual_match`` searches a template across *scales* (DPI / zoom tolerance) but
+assumes the template is axis-aligned — a control that is rendered at a slight skew,
+a rotated icon, or a knob/dial at a different angle is missed because OpenCV's
+``matchTemplate`` is not rotation-invariant. This sweeps a set of rotation
+*angles* (each warped with ``cv2.warpAffine``) crossed with a scale-space
+(``np.linspace`` pyramid), correlates every (scale, angle) candidate and keeps the
+best — reporting the winning ``angle`` and ``scale`` so the caller knows the pose.
+
+It reuses ``visual_match``'s grayscale loaders, scale resize, correlation method
+table and non-maximum suppression, so no matching or geometry code is duplicated.
+The ``haystack`` is injectable (ndarray / path / PIL), so the search is unit-testable
+on synthetic arrays; only the default (grab the screen) is device-bound. OpenCV +
+NumPy arrive via the project's ``je_open_cv`` dependency and are imported lazily.
+Imports no ``PySide6``.
+"""
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+from je_auto_control.utils.visual_match.visual_match import (
+    _haystack_gray, _method, _nms, _resize, _to_gray,
+)
+
+ImageSource = Any
+
+
+@dataclass(frozen=True)
+class RotatedMatch:
+    """One match with its recovered pose: top-left, size, score, scale, angle."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+    score: float
+    scale: float
+    angle: float
+
+    @property
+    def center(self) -> List[int]:
+        """The match's centre point ``[x, y]`` (ready to click)."""
+        return [self.x + self.width // 2, self.y + self.height // 2]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the match as a plain dict including the centre point."""
+        data = asdict(self)
+        data["center"] = self.center
+        return data
+
+
+def _rotate(template, angle: float):
+    """Rotate ``template`` by ``angle`` degrees, expanding the canvas to fit it."""
+    import cv2
+    if abs(angle) < 1e-9:
+        return template
+    height, width = template.shape[:2]
+    center = (width / 2.0, height / 2.0)
+    matrix = cv2.getRotationMatrix2D(center, float(angle), 1.0)
+    cos = abs(matrix[0, 0])
+    sin = abs(matrix[0, 1])
+    new_w = int(height * sin + width * cos)
+    new_h = int(height * cos + width * sin)
+    matrix[0, 2] += (new_w / 2.0) - center[0]
+    matrix[1, 2] += (new_h / 2.0) - center[1]
+    return cv2.warpAffine(template, matrix, (new_w, new_h))
+
+
+def scale_space(min_scale: float = 0.8, max_scale: float = 1.25,
+                steps: int = 5) -> List[float]:
+    """Return ``steps`` evenly spaced scales in ``[min_scale, max_scale]``."""
+    import numpy as np
+    return [round(float(s), 4)
+            for s in np.linspace(float(min_scale), float(max_scale), int(steps))]
+
+
+def _best_at(hay, tmpl, scale: float, angle: float, metric: int):
+    """Return the best ``RotatedMatch`` for one (scale, angle), or ``None``."""
+    import cv2
+    warped = _rotate(_resize(tmpl, float(scale)), float(angle))
+    if warped.shape[0] > hay.shape[0] or warped.shape[1] > hay.shape[1]:
+        return None
+    _, max_val, _, max_loc = cv2.minMaxLoc(cv2.matchTemplate(hay, warped, metric))
+    return RotatedMatch(int(max_loc[0]), int(max_loc[1]), warped.shape[1],
+                        warped.shape[0], round(float(max_val), 4),
+                        float(scale), float(angle))
+
+
+def _sweep(template: ImageSource, haystack: Optional[ImageSource],
+           region: Optional[Sequence[int]], scales: Sequence[float],
+           angles: Sequence[float], method: str) -> List[RotatedMatch]:
+    """Correlate every (scale, angle) candidate and return them all."""
+    tmpl = _to_gray(template)
+    hay = _haystack_gray(haystack, region)
+    metric = _method(method)
+    found: List[RotatedMatch] = []
+    for scale in scales:
+        for angle in angles:
+            candidate = _best_at(hay, tmpl, scale, angle, metric)
+            if candidate is not None:
+                found.append(candidate)
+    return found
+
+
+def match_rotated(template: ImageSource, *, haystack: Optional[ImageSource] = None,
+                  region: Optional[Sequence[int]] = None,
+                  scales: Sequence[float] = (1.0,),
+                  angles: Sequence[float] = (0.0,), min_score: float = 0.8,
+                  method: str = "ccoeff_normed") -> Optional[RotatedMatch]:
+    """Return the single best match over the scale x angle sweep, or ``None``.
+
+    Each angle in ``angles`` (degrees) is applied to the template at each scale in
+    ``scales``; the highest-scoring hit at or above ``min_score`` wins, carrying the
+    recovered ``scale`` and ``angle``.
+    """
+    best: Optional[RotatedMatch] = None
+    for candidate in _sweep(template, haystack, region, scales, angles, method):
+        if candidate.score >= min_score and (best is None
+                                             or candidate.score > best.score):
+            best = candidate
+    return best
+
+
+def match_rotated_all(template: ImageSource, *,
+                      haystack: Optional[ImageSource] = None,
+                      region: Optional[Sequence[int]] = None,
+                      scales: Sequence[float] = (1.0,),
+                      angles: Sequence[float] = (0.0,), min_score: float = 0.8,
+                      method: str = "ccoeff_normed", max_results: int = 20,
+                      nms_iou: float = 0.3) -> List[RotatedMatch]:
+    """Return every match >= ``min_score`` over the sweep, overlaps removed (NMS).
+
+    Detections from neighbouring scales / angles that overlap are merged by
+    non-maximum suppression (highest score kept), ordered by score and capped at
+    ``max_results``.
+    """
+    hits = [c for c in _sweep(template, haystack, region, scales, angles, method)
+            if c.score >= min_score]
+    return _nms(hits, float(nms_iou))[:int(max_results)]

--- a/test/unit_test/headless/test_rotated_match_batch.py
+++ b/test/unit_test/headless/test_rotated_match_batch.py
@@ -1,0 +1,90 @@
+"""Headless tests for rotation/scale-tolerant matching on synthetic arrays."""
+import pytest
+
+import je_auto_control as ac
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("cv2")
+
+from je_auto_control.utils.rotated_match import (  # noqa: E402
+    match_rotated, match_rotated_all, scale_space,
+)
+from je_auto_control.utils.rotated_match.rotated_match import _rotate  # noqa: E402
+
+
+def _template():
+    # asymmetric (left half bright) so the best-correlating angle is unambiguous
+    tmpl = np.zeros((24, 24), dtype=np.uint8)
+    tmpl[:, :12] = 200
+    return tmpl
+
+
+def _haystack_with(patch, top, left):
+    hay = np.zeros((140, 160), dtype=np.uint8)
+    height, width = patch.shape[:2]
+    hay[top:top + height, left:left + width] = patch
+    return hay
+
+
+def test_finds_rotated_template_and_recovers_angle():
+    tmpl = _template()
+    rotated = _rotate(tmpl, 30.0)
+    hay = _haystack_with(rotated, top=50, left=40)
+    best = match_rotated(tmpl, haystack=hay, angles=(0.0, 15.0, 30.0, 45.0),
+                         min_score=0.9)
+    assert best is not None
+    assert abs(best.angle - 30.0) < 1e-9
+    assert best.score >= 0.99
+    assert abs(best.x - 40) <= 1 and abs(best.y - 50) <= 1
+
+
+def test_zero_angle_locates_unrotated_patch():
+    tmpl = _template()
+    hay = _haystack_with(tmpl, top=20, left=30)
+    best = match_rotated(tmpl, haystack=hay, angles=(0.0,), min_score=0.9)
+    assert best is not None
+    assert abs(best.angle) < 1e-9
+    assert best.center == [30 + 12, 20 + 12]
+
+
+def test_no_match_returns_none():
+    tmpl = _template()
+    hay = np.zeros((140, 160), dtype=np.uint8)  # template absent
+    assert match_rotated(tmpl, haystack=hay, angles=(0.0, 30.0),
+                         min_score=0.95) is None
+
+
+def test_match_all_dedupes_overlaps():
+    tmpl = _template()
+    rotated = _rotate(tmpl, 30.0)
+    hay = _haystack_with(rotated, top=50, left=40)
+    # neighbouring angles overlap on the same spot; NMS collapses them to one
+    hits = match_rotated_all(tmpl, haystack=hay, angles=(28.0, 30.0, 32.0),
+                             min_score=0.85, nms_iou=0.3)
+    assert len(hits) == 1
+    assert abs(hits[0].angle - 30.0) < 1e-9
+
+
+def test_scale_space_is_evenly_spaced_inclusive():
+    scales = scale_space(0.8, 1.2, 3)
+    assert len(scales) == 3
+    assert abs(scales[0] - 0.8) < 1e-9
+    assert abs(scales[1] - 1.0) < 1e-9
+    assert abs(scales[2] - 1.2) < 1e-9
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    assert "AC_match_rotated" in set(ac.executor.known_commands())
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert "ac_match_rotated" in names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert "AC_match_rotated" in specs
+
+
+def test_facade_exports():
+    assert hasattr(ac, "match_rotated") and "match_rotated" in ac.__all__
+    assert hasattr(ac, "match_rotated_all")


### PR DESCRIPTION
## Summary
Adds `match_rotated` / `match_rotated_all` — template matching that tolerates **rotation** (not just scale). `match_template` sweeps scales but assumes axis-aligned templates; OpenCV's `matchTemplate` is not rotation-invariant, so a skewed control, a rotated icon, or a dial/knob at a different angle is missed. This sweeps `angles` (each warped with `cv2.warpAffine`) crossed with a `np.linspace` scale-space and returns the best-correlating `RotatedMatch`, carrying the recovered **scale + angle** so the caller knows the pose.

Reuses `visual_match`'s grayscale loaders, scale resize, correlation-method table and NMS — no matching or geometry code is duplicated. Injectable `haystack`; Qt-free.

## Layers
- **Core**: `utils/rotated_match/` — `RotatedMatch`, `match_rotated`, `match_rotated_all`, `scale_space`.
- **Facade**: re-exported from `je_auto_control` + `__all__`.
- **Executor**: `AC_match_rotated` (`{found, match}`) / `AC_match_rotated_all` (`{count, matches}`).
- **MCP**: `ac_match_rotated` / `ac_match_rotated_all` (read-only).
- **Script Builder**: **Match Template (rotated)** / **Match Template All (rotated)** under **Image**.
- **Docs**: v158 EN + Zh + toctree.
- **Changelog**: root EN + zh-TW + zh-CN.

## Tests
`test/unit_test/headless/test_rotated_match_batch.py` — recovers a known rotation angle, locates an unrotated patch, returns `None` when absent, NMS collapses neighbouring angles, `scale_space` spacing, full wiring + facade exports. 7 passed. ruff / bandit / radon / float-scan / Qt-free all clean.