### PR TITLE
Add coarse labelled screen grid for VLM grounding

### DIFF
--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 粗粒度标签屏幕网格(VLM Grounding)
+
+以网格单元格(「点击 C3」)而非原始像素引用屏幕区域。完整参考:[`docs/source/Zh/doc/new_features/v159_features_doc.rst`](../docs/source/Zh/doc/new_features/v159_features_doc.rst)。
+
+- **`grid_cells` / `cell_for_point` / `point_for_cell`**(`AC_grid_cells`、`AC_cell_for_point`、`AC_point_for_cell`):VLM grounding 在模型指名粗粒度单元格时,远比输出容易幻觉的像素坐标更可靠。本功能在屏幕(或 `region`)上铺设 `rows`x`cols` 网格,以电子表格风格标记每个单元格(左上 `A1`,超过 `Z` → `AA`),并双向对应——点 → 包含的单元格、指名单元格 → 中心点(可直接点击)。纯标准库几何;唯一设备相关的路径是读取实时屏幕尺寸的默认行为,因此每个函数都可通过明确 `region` 无头测试。不导入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 旋转与缩放容忍的模板匹配
 
 不只缩放,还能找到旋转或倾斜的模板。完整参考:[`docs/source/Zh/doc/new_features/v158_features_doc.rst`](../docs/source/Zh/doc/new_features/v158_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 粗粒度標籤螢幕網格(VLM Grounding)
+
+以網格儲存格(「點擊 C3」)而非原始像素引用螢幕區域。完整參考:[`docs/source/Zh/doc/new_features/v159_features_doc.rst`](../docs/source/Zh/doc/new_features/v159_features_doc.rst)。
+
+- **`grid_cells` / `cell_for_point` / `point_for_cell`**(`AC_grid_cells`、`AC_cell_for_point`、`AC_point_for_cell`):VLM grounding 在模型指名粗粒度儲存格時,遠比輸出容易幻覺的像素座標更可靠。本功能在螢幕(或 `region`)上鋪設 `rows`x`cols` 網格,以試算表風格標記每個儲存格(左上 `A1`,超過 `Z` → `AA`),並雙向對應——點 → 包含的儲存格、指名儲存格 → 中心點(可直接點擊)。純標準函式庫幾何;唯一裝置相依的路徑是讀取即時螢幕尺寸的預設行為,因此每個函式都可透過明確 `region` 無頭測試。不匯入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 旋轉與縮放容忍的樣板比對
 
 不只縮放,還能找到旋轉或傾斜的樣板。完整參考:[`docs/source/Zh/doc/new_features/v158_features_doc.rst`](../docs/source/Zh/doc/new_features/v158_features_doc.rst)。

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Coarse Labelled Screen Grid (VLM Grounding)
+
+Refer to screen regions as grid cells ("click C3") instead of raw pixels. Full reference: [`docs/source/Eng/doc/new_features/v159_features_doc.rst`](docs/source/Eng/doc/new_features/v159_features_doc.rst).
+
+- **`grid_cells` / `cell_for_point` / `point_for_cell`** (`AC_grid_cells`, `AC_cell_for_point`, `AC_point_for_cell`): VLM grounding is far more reliable when a model names a coarse cell than when it emits hallucinated pixel coordinates. This lays an `rows`x`cols` grid over the screen (or a `region`), labels each cell spreadsheet-style (`A1` top-left, past `Z` → `AA`), and maps both ways — point → containing cell, named cell → centre point (ready to click). Pure-stdlib geometry; the only device-bound path is the default that reads the live screen size, so every function is headless-testable with an explicit `region`. No `PySide6`.
+
 ## What's new (2026-06-23) — Rotation- & Scale-Tolerant Template Matching
 
 Find templates that are rotated or skewed, not just scaled. Full reference: [`docs/source/Eng/doc/new_features/v158_features_doc.rst`](docs/source/Eng/doc/new_features/v158_features_doc.rst).

--- a/docs/source/Eng/doc/new_features/v159_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v159_features_doc.rst
@@ -1,0 +1,47 @@
+Coarse Labelled Screen Grid (VLM Grounding)
+===========================================
+
+Vision / VLM grounding works far better when a model can refer to a *coarse cell*
+("click cell C3") than to raw pixel coordinates, which it tends to hallucinate — a
+labelled overlay grid is the standard way to describe a screenshot to such a model and
+to map its answer back to a point. The framework had no such helper. ``screen_grid``
+lays an ``rows`` x ``cols`` grid over the screen (or a sub-``region``), labels each cell
+spreadsheet-style (column letter + row number, ``A1`` top-left) and converts both ways.
+
+Pure-stdlib geometry; the only device-bound path is the default that grabs the live
+screen size when neither ``region`` nor ``screen_size`` is given, so every function is
+fully unit-testable by passing an explicit region. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import grid_cells, cell_for_point, point_for_cell, click
+
+    # describe the screen to a model as a 4x4 grid
+    for cell in grid_cells(4, 4):
+        print(cell.label, cell.center)
+
+    # the model answers "C3" -> turn it into a click
+    click(*point_for_cell("C3", 4, 4))
+
+    # which cell did the user click in?
+    cell = cell_for_point(820, 410, 4, 4)
+    print(cell.label if cell else "outside")
+
+``grid_cells(rows, cols, *, region=None, screen_size=None)`` returns row-major
+``GridCell`` objects (``label`` / ``row`` / ``col`` / ``left`` / ``top`` / ``right`` /
+``bottom`` + ``center``). ``cell_for_point`` returns the containing cell (or ``None`` if
+the point is outside the region); ``point_for_cell`` returns the centre ``[x, y]`` of a
+named cell, ready to click. Labels run past ``Z`` spreadsheet-style (``AA``, ``AB`` …).
+
+Executor commands
+-----------------
+
+``AC_grid_cells`` (``rows`` / ``cols`` / ``region`` → ``{count, cells}``),
+``AC_cell_for_point`` (``x`` / ``y`` / ``rows`` / ``cols`` / ``region`` →
+``{found, cell}``) and ``AC_point_for_cell`` (``label`` / ``rows`` / ``cols`` /
+``region`` → ``{point}``). They are exposed as the MCP tools ``ac_grid_cells`` /
+``ac_cell_for_point`` / ``ac_point_for_cell`` (read-only) and as Script Builder
+commands under **Image**.

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -181,6 +181,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v156_features_doc
    doc/new_features/v157_features_doc
    doc/new_features/v158_features_doc
+   doc/new_features/v159_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/doc/new_features/v159_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v159_features_doc.rst
@@ -1,0 +1,45 @@
+粗粒度標籤螢幕網格(VLM Grounding)
+==================================
+
+視覺 / VLM grounding 在模型能引用*粗粒度儲存格*(「點擊 C3 格」)時,遠比引用容易
+幻覺的原始像素座標更可靠——疊加標籤網格正是向此類模型描述截圖、並將其回答對應回
+座標點的標準做法。框架先前沒有這個輔助工具。``screen_grid`` 在螢幕(或子 ``region``)
+上鋪設 ``rows`` x ``cols`` 網格,以試算表風格標記每個儲存格(欄字母 + 列號,左上為
+``A1``),並雙向轉換。
+
+純標準函式庫幾何;唯一裝置相依的路徑是當未提供 ``region`` 或 ``screen_size`` 時抓取
+即時螢幕尺寸的預設行為,因此每個函式都可透過傳入明確區域完整單元測試。不匯入
+``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import grid_cells, cell_for_point, point_for_cell, click
+
+    # 以 4x4 網格向模型描述螢幕
+    for cell in grid_cells(4, 4):
+        print(cell.label, cell.center)
+
+    # 模型回答「C3」-> 轉成點擊
+    click(*point_for_cell("C3", 4, 4))
+
+    # 使用者點在哪個儲存格?
+    cell = cell_for_point(820, 410, 4, 4)
+    print(cell.label if cell else "outside")
+
+``grid_cells(rows, cols, *, region=None, screen_size=None)`` 回傳列優先的
+``GridCell`` 物件(``label`` / ``row`` / ``col`` / ``left`` / ``top`` / ``right`` /
+``bottom`` + ``center``)。``cell_for_point`` 回傳包含該點的儲存格(點在區域外則回傳
+``None``);``point_for_cell`` 回傳指定儲存格的中心 ``[x, y]``,可直接點擊。標籤超過
+``Z`` 後以試算表風格延續(``AA``、``AB`` …)。
+
+執行器指令
+----------
+
+``AC_grid_cells``(``rows`` / ``cols`` / ``region`` → ``{count, cells}``)、
+``AC_cell_for_point``(``x`` / ``y`` / ``rows`` / ``cols`` / ``region`` →
+``{found, cell}``)與 ``AC_point_for_cell``(``label`` / ``rows`` / ``cols`` /
+``region`` → ``{point}``)。三者以 MCP 工具 ``ac_grid_cells`` / ``ac_cell_for_point`` /
+``ac_point_for_cell``(唯讀)及 Script Builder 指令(位於 **Image** 分類下)形式提供。

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -181,6 +181,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v156_features_doc
    doc/new_features/v157_features_doc
    doc/new_features/v158_features_doc
+   doc/new_features/v159_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -283,6 +283,10 @@ from je_auto_control.utils.visual_match import Match as TemplateMatch
 from je_auto_control.utils.rotated_match import (
     RotatedMatch, match_rotated, match_rotated_all, scale_space,
 )
+# Coarse labelled cell grid for VLM grounding (point <-> cell mapping)
+from je_auto_control.utils.screen_grid import (
+    GridCell, cell_for_point, grid_cells, point_for_cell,
+)
 # Locate on-screen regions by colour (mask + connected components)
 from je_auto_control.utils.color_region import (
     find_color_region, find_color_regions,
@@ -1190,6 +1194,10 @@ __all__ = [
     "match_rotated",
     "match_rotated_all",
     "scale_space",
+    "GridCell",
+    "grid_cells",
+    "cell_for_point",
+    "point_for_cell",
     "find_color_region",
     "find_color_regions",
     "ssim_compare",

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -336,6 +336,39 @@ def _add_image_specs(specs: List[CommandSpec]) -> None:
         description="Find every rotation/scale-tolerant match (NMS-deduped).",
     ))
     specs.append(CommandSpec(
+        "AC_grid_cells", "Image", "Grid Cells (coarse grounding)",
+        fields=(
+            FieldSpec("rows", FieldType.INT, optional=True, default=3),
+            FieldSpec("cols", FieldType.INT, optional=True, default=3),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Label an rows x cols grid over the screen for VLM grounding.",
+    ))
+    specs.append(CommandSpec(
+        "AC_cell_for_point", "Image", "Cell For Point",
+        fields=(
+            FieldSpec("x", FieldType.INT),
+            FieldSpec("y", FieldType.INT),
+            FieldSpec("rows", FieldType.INT, optional=True, default=3),
+            FieldSpec("cols", FieldType.INT, optional=True, default=3),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Return the grid cell label containing a screen point.",
+    ))
+    specs.append(CommandSpec(
+        "AC_point_for_cell", "Image", "Point For Cell",
+        fields=(
+            FieldSpec("label", FieldType.STRING, placeholder="C3"),
+            FieldSpec("rows", FieldType.INT, optional=True, default=3),
+            FieldSpec("cols", FieldType.INT, optional=True, default=3),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Return the centre point of a named grid cell (click target).",
+    ))
+    specs.append(CommandSpec(
         "AC_find_color_region", "Image", "Find Colour Region",
         fields=(
             FieldSpec("rgb", FieldType.STRING, placeholder="[0, 200, 0]"),

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3323,6 +3323,40 @@ def _match_rotated_all(template: str, min_score: Any = 0.8, scales: Any = None,
     return {"count": len(matches), "matches": [m.to_dict() for m in matches]}
 
 
+def _region_arg(value: Any) -> Optional[List[int]]:
+    """Coerce a JSON-string / list region arg into a list of ints, or None."""
+    import json
+    if isinstance(value, str):
+        value = json.loads(value) if value.strip() else None
+    return [int(v) for v in value] if value else None
+
+
+def _grid_cells(rows: Any, cols: Any, region: Any = None) -> Dict[str, Any]:
+    """Adapter: every cell of an rows x cols labelled grid over the screen."""
+    from je_auto_control.utils.screen_grid import grid_cells
+    cells = grid_cells(int(rows), int(cols), region=_region_arg(region))
+    return {"count": len(cells), "cells": [c.to_dict() for c in cells]}
+
+
+def _cell_for_point(x: Any, y: Any, rows: Any, cols: Any,
+                    region: Any = None) -> Dict[str, Any]:
+    """Adapter: the grid cell containing a point (or found=False if outside)."""
+    from je_auto_control.utils.screen_grid import cell_for_point
+    cell = cell_for_point(int(x), int(y), int(rows), int(cols),
+                          region=_region_arg(region))
+    return {"found": cell is not None,
+            "cell": cell.to_dict() if cell else None}
+
+
+def _point_for_cell(label: str, rows: Any, cols: Any,
+                    region: Any = None) -> Dict[str, Any]:
+    """Adapter: the centre point of a named grid cell (ready to click)."""
+    from je_auto_control.utils.screen_grid import point_for_cell
+    point = point_for_cell(str(label), int(rows), int(cols),
+                           region=_region_arg(region))
+    return {"point": point}
+
+
 def _find_color_region(rgb: Any, tolerance: Any = 20, min_area: Any = 50,
                        region: Any = None) -> Dict[str, Any]:
     """Adapter: locate coloured regions on the screen, largest first."""
@@ -5727,6 +5761,9 @@ class Executor:
             "AC_match_masked_all": _match_masked_all,
             "AC_match_rotated": _match_rotated,
             "AC_match_rotated_all": _match_rotated_all,
+            "AC_grid_cells": _grid_cells,
+            "AC_cell_for_point": _cell_for_point,
+            "AC_point_for_cell": _point_for_cell,
             "AC_ssim_compare": _ssim_compare,
             "AC_ssim_changed_regions": _ssim_changed_regions,
             "AC_feature_match": _feature_match,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3578,6 +3578,52 @@ def rotated_match_tools() -> List[MCPTool]:
     ]
 
 
+def screen_grid_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_grid_cells",
+            description=("Lay an 'rows' x 'cols' labelled grid over the screen (or "
+                         "'region') for coarse VLM grounding. Returns {count, cells:"
+                         "[{label,row,col,left,top,right,bottom,center}]}; labels are "
+                         "spreadsheet-style ('A1' top-left)."),
+            input_schema=schema({
+                "rows": {"type": "integer"},
+                "cols": {"type": "integer"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["rows", "cols"]),
+            handler=h.grid_cells,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_cell_for_point",
+            description=("Return the grid cell containing point (x, y) over an 'rows' "
+                         "x 'cols' grid: {found, cell}. found=false if outside."),
+            input_schema=schema({
+                "x": {"type": "integer"},
+                "y": {"type": "integer"},
+                "rows": {"type": "integer"},
+                "cols": {"type": "integer"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["x", "y", "rows", "cols"]),
+            handler=h.cell_for_point,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_point_for_cell",
+            description=("Return the centre point {point:[x,y]} of grid cell 'label' "
+                         "(e.g. 'C3') over an 'rows' x 'cols' grid - ready to click."),
+            input_schema=schema({
+                "label": {"type": "string"},
+                "rows": {"type": "integer"},
+                "cols": {"type": "integer"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["label", "rows", "cols"]),
+            handler=h.point_for_cell,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def grid_locator_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6969,7 +7015,7 @@ ALL_FACTORIES = (
     process_doc_tools, tween_drag_tools, mouse_path_tools, field_entry_tools,
     key_hold_tools, mouse_relative_tools, text_unicode_tools,
     modifier_state_tools, grid_locator_tools, visual_match_tools,
-    rotated_match_tools,
+    rotated_match_tools, screen_grid_tools,
     color_region_tools, ssim_tools, feature_match_tools, shape_locator_tools,
     window_layout_tools, window_arrange_tools, preprocess_tools,
     monitor_layout_tools, actionability_tools, element_parse_tools,

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2108,6 +2108,21 @@ def match_rotated_all(template, min_score=0.8, scales=None, angles=None,
                               nms_iou, region)
 
 
+def grid_cells(rows, cols, region=None):
+    from je_auto_control.utils.executor.action_executor import _grid_cells
+    return _grid_cells(rows, cols, region)
+
+
+def cell_for_point(x, y, rows, cols, region=None):
+    from je_auto_control.utils.executor.action_executor import _cell_for_point
+    return _cell_for_point(x, y, rows, cols, region)
+
+
+def point_for_cell(label, rows, cols, region=None):
+    from je_auto_control.utils.executor.action_executor import _point_for_cell
+    return _point_for_cell(label, rows, cols, region)
+
+
 def find_color_region(rgb, tolerance=20, min_area=50, region=None):
     from je_auto_control.utils.executor.action_executor import (
         _find_color_region)

--- a/je_auto_control/utils/screen_grid/__init__.py
+++ b/je_auto_control/utils/screen_grid/__init__.py
@@ -1,0 +1,6 @@
+"""Coarse labelled cell grid for VLM grounding (point <-> cell mapping)."""
+from je_auto_control.utils.screen_grid.screen_grid import (
+    GridCell, cell_for_point, grid_cells, point_for_cell,
+)
+
+__all__ = ["GridCell", "cell_for_point", "grid_cells", "point_for_cell"]

--- a/je_auto_control/utils/screen_grid/screen_grid.py
+++ b/je_auto_control/utils/screen_grid/screen_grid.py
@@ -1,0 +1,137 @@
+"""Coarse labelled cell grid over the screen (or a region).
+
+Vision / VLM grounding works far better when the model can refer to a *coarse cell*
+("click cell C3") than to raw pixel coordinates it tends to hallucinate, and a labelled
+grid is the standard way to describe a screenshot to such a model and to map its answer
+back to a point. The framework had no such helper. This lays an ``rows x cols`` grid over
+the screen (or a sub-``region``), labels each cell spreadsheet-style (column letter + row
+number, ``A1`` top-left) and converts both ways: point -> containing cell, and cell ->
+centre point (ready to click).
+
+Pure-stdlib geometry; the only device-bound path is the default that grabs the live screen
+size when neither ``region`` nor ``screen_size`` is given, so every function is fully
+unit-testable by passing an explicit region. Imports no ``PySide6``.
+"""
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+_LABEL_RE = re.compile(r"([A-Za-z]+)(\d+)")
+
+
+@dataclass(frozen=True)
+class GridCell:
+    """One grid cell: spreadsheet ``label``, 0-based ``row`` / ``col`` and bounds."""
+
+    label: str
+    row: int
+    col: int
+    left: int
+    top: int
+    right: int
+    bottom: int
+
+    @property
+    def center(self) -> List[int]:
+        """The cell's centre point ``[x, y]`` (ready to click)."""
+        return [(self.left + self.right) // 2, (self.top + self.bottom) // 2]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the cell as a plain dict including the centre point."""
+        data = asdict(self)
+        data["center"] = self.center
+        return data
+
+
+def _col_label(index: int) -> str:
+    """0-based column index -> spreadsheet letters (0 -> 'A', 26 -> 'AA')."""
+    label, number = "", index + 1
+    while number > 0:
+        number, remainder = divmod(number - 1, 26)
+        label = chr(ord("A") + remainder) + label
+    return label
+
+
+def _col_index(letters: str) -> int:
+    """Spreadsheet letters -> 0-based column index ('A' -> 0, 'AA' -> 26)."""
+    number = 0
+    for char in letters.upper():
+        number = number * 26 + (ord(char) - ord("A") + 1)
+    return number - 1
+
+
+def _bounds(region: Optional[Sequence[int]],
+            screen_size: Optional[Sequence[int]]) -> Tuple[int, int, int, int]:
+    """Resolve the grid rectangle from ``region`` / ``screen_size`` / live screen."""
+    if region is not None:
+        left, top, right, bottom = (int(v) for v in region)
+        return left, top, right, bottom
+    if screen_size is not None:
+        width, height = (int(v) for v in screen_size)
+        return 0, 0, width, height
+    from je_auto_control.wrapper.auto_control_screen import screen_size as _live
+    width, height = _live()
+    return 0, 0, int(width), int(height)
+
+
+def _edges(start: int, length: int, count: int) -> List[int]:
+    """Return ``count`` + 1 evenly spaced integer edges starting at ``start``."""
+    return [start + round(i * length / count) for i in range(count + 1)]
+
+
+def _validate(rows: int, cols: int) -> Tuple[int, int]:
+    """Coerce and check the grid shape; both dimensions must be >= 1."""
+    rows, cols = int(rows), int(cols)
+    if rows < 1 or cols < 1:
+        raise ValueError("rows and cols must both be >= 1")
+    return rows, cols
+
+
+def _make_cell(row: int, col: int, xs: List[int], ys: List[int]) -> GridCell:
+    """Build a ``GridCell`` from a row/col and the precomputed edge arrays."""
+    return GridCell(f"{_col_label(col)}{row + 1}", row, col,
+                    xs[col], ys[row], xs[col + 1], ys[row + 1])
+
+
+def grid_cells(rows: int, cols: int, *, region: Optional[Sequence[int]] = None,
+               screen_size: Optional[Sequence[int]] = None) -> List[GridCell]:
+    """Return every cell of an ``rows`` x ``cols`` grid over the region, row-major."""
+    rows, cols = _validate(rows, cols)
+    left, top, right, bottom = _bounds(region, screen_size)
+    xs = _edges(left, right - left, cols)
+    ys = _edges(top, bottom - top, rows)
+    return [_make_cell(row, col, xs, ys)
+            for row in range(rows) for col in range(cols)]
+
+
+def cell_for_point(x: int, y: int, rows: int, cols: int, *,
+                   region: Optional[Sequence[int]] = None,
+                   screen_size: Optional[Sequence[int]] = None
+                   ) -> Optional[GridCell]:
+    """Return the cell containing ``(x, y)``, or ``None`` if outside the region."""
+    rows, cols = _validate(rows, cols)
+    left, top, right, bottom = _bounds(region, screen_size)
+    if not (left <= x < right and top <= y < bottom):
+        return None
+    col = min(cols - 1, int((x - left) * cols / (right - left)))
+    row = min(rows - 1, int((y - top) * rows / (bottom - top)))
+    xs = _edges(left, right - left, cols)
+    ys = _edges(top, bottom - top, rows)
+    return _make_cell(row, col, xs, ys)
+
+
+def point_for_cell(label: str, rows: int, cols: int, *,
+                   region: Optional[Sequence[int]] = None,
+                   screen_size: Optional[Sequence[int]] = None) -> List[int]:
+    """Return the centre point ``[x, y]`` of the cell named ``label`` (e.g. ``'C3'``)."""
+    rows, cols = _validate(rows, cols)
+    match = _LABEL_RE.fullmatch(label.strip())
+    if not match:
+        raise ValueError(f"invalid cell label: {label!r}")
+    col, row = _col_index(match.group(1)), int(match.group(2)) - 1
+    if not (0 <= col < cols and 0 <= row < rows):
+        raise ValueError(f"cell {label!r} is outside a {rows}x{cols} grid")
+    left, top, right, bottom = _bounds(region, screen_size)
+    xs = _edges(left, right - left, cols)
+    ys = _edges(top, bottom - top, rows)
+    return _make_cell(row, col, xs, ys).center

--- a/test/unit_test/headless/test_screen_grid_batch.py
+++ b/test/unit_test/headless/test_screen_grid_batch.py
@@ -1,0 +1,81 @@
+"""Headless tests for the coarse labelled screen grid (pure stdlib)."""
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.screen_grid import (
+    cell_for_point, grid_cells, point_for_cell,
+)
+
+REGION = [0, 0, 400, 200]
+
+
+def test_grid_cells_cover_region_row_major():
+    cells = grid_cells(2, 4, region=REGION)
+    assert len(cells) == 8
+    assert [c.label for c in cells[:4]] == ["A1", "B1", "C1", "D1"]
+    assert cells[0].left == 0 and cells[0].right == 100
+    assert cells[-1].label == "D2" and cells[-1].right == 400
+    assert cells[-1].bottom == 200
+
+
+def test_cell_for_point_inside():
+    cell = cell_for_point(150, 50, 2, 4, region=REGION)
+    assert cell is not None
+    assert cell.label == "B1"  # x 150 -> col 1, y 50 -> row 0
+
+
+def test_cell_for_point_outside_is_none():
+    assert cell_for_point(500, 50, 2, 4, region=REGION) is None
+    assert cell_for_point(10, -1, 2, 4, region=REGION) is None
+
+
+def test_point_for_cell_returns_centre():
+    # C1 is the third column of four over width 400 -> x in [200,300), centre 250
+    assert point_for_cell("C1", 2, 4, region=REGION) == [250, 50]
+
+
+def test_round_trip_point_to_cell_to_point():
+    cell = cell_for_point(317, 133, 3, 3, region=REGION)
+    assert cell is not None
+    back = point_for_cell(cell.label, 3, 3, region=REGION)
+    again = cell_for_point(back[0], back[1], 3, 3, region=REGION)
+    assert again.label == cell.label
+
+
+def test_screen_size_default_origin():
+    cells = grid_cells(1, 2, screen_size=[200, 100])
+    assert cells[0].left == 0 and cells[1].right == 200
+    assert cells[0].bottom == 100
+
+
+def test_spreadsheet_labels_past_z():
+    cells = grid_cells(1, 27, region=[0, 0, 270, 10])
+    assert cells[25].label == "Z1"
+    assert cells[26].label == "AA1"
+
+
+def test_invalid_shape_and_label_raise():
+    with pytest.raises(ValueError):
+        grid_cells(0, 4, region=REGION)
+    with pytest.raises(ValueError):
+        point_for_cell("Z9", 2, 2, region=REGION)
+    with pytest.raises(ValueError):
+        point_for_cell("nope", 2, 2, region=REGION)
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_grid_cells", "AC_cell_for_point", "AC_point_for_cell"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_grid_cells", "ac_cell_for_point", "ac_point_for_cell"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_grid_cells", "AC_cell_for_point", "AC_point_for_cell"} <= specs
+
+
+def test_facade_exports():
+    for name in ("grid_cells", "cell_for_point", "point_for_cell", "GridCell"):
+        assert hasattr(ac, name) and name in ac.__all__


### PR DESCRIPTION
## Summary
Adds `grid_cells` / `cell_for_point` / `point_for_cell` — a coarse **labelled grid** over the screen (or a `region`) for vision/VLM grounding. Models ground far more reliably onto a named cell ("click C3") than onto raw pixel coordinates they tend to hallucinate; a labelled overlay grid is the standard way to describe a screenshot to a model and map its answer back to a point. The framework had no such helper.

Cells are labelled spreadsheet-style (`A1` top-left, past `Z` → `AA`). `cell_for_point` maps a point to its containing cell; `point_for_cell` maps a named cell to its centre (ready to click). Pure-stdlib geometry — the only device-bound path is the default that reads the live screen size, so every function is headless-testable with an explicit `region`. Qt-free.

## Layers
- **Core**: `utils/screen_grid/` — `GridCell`, `grid_cells`, `cell_for_point`, `point_for_cell`.
- **Facade**: re-exported from `je_auto_control` + `__all__`.
- **Executor**: `AC_grid_cells` / `AC_cell_for_point` / `AC_point_for_cell`.
- **MCP**: `ac_grid_cells` / `ac_cell_for_point` / `ac_point_for_cell` (read-only).
- **Script Builder**: **Grid Cells** / **Cell For Point** / **Point For Cell** under **Image**.
- **Docs**: v159 EN + Zh + toctree.
- **Changelog**: root EN + zh-TW + zh-CN.

## Tests
`test/unit_test/headless/test_screen_grid_batch.py` — cells cover region row-major, point→cell, outside→None, cell→centre, round-trip, screen_size default, labels past Z (AA), invalid shape/label raise, full wiring + facade exports. 10 passed. ruff / bandit / radon / float-scan / Qt-free all clean.