### PR TITLE
Add clipboard file-drop list (CF_HDROP)

### DIFF
--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 剪贴板文件拖放列表(CF_HDROP)
+
+把一份文件列表放上剪贴板,可直接粘贴进 Explorer。完整参考:[`docs/source/Zh/doc/new_features/v160_features_doc.rst`](../docs/source/Zh/doc/new_features/v160_features_doc.rst)。
+
+- **`build_dropfiles` / `parse_dropfiles` / `set_clipboard_files` / `get_clipboard_files`**(`AC_set_clipboard_files`、`AC_get_clipboard_files`):剪贴板原本能承载文本、图像与(通过 `rich_clipboard`)HTML,却从未支持*文件列表*——也就是 Explorer 读取以进行真正文件复制的 `CF_HDROP` 内容。构建它相当繁琐(20 字节 `DROPFILES` 头 + 双重 null 结尾的 UTF-16 路径列表 + `pFiles` 偏移)。本功能把封装独立为纯粹、可完整测试的 `build_dropfiles` / `parse_dropfiles` 字节函数,其上再叠加仅限 Windows 的 `set`/`get_clipboard_files` 薄包装——与 `rich_clipboard` 处理 `CF_HTML` 的拆分方式相同。不导入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 粗粒度标签屏幕网格(VLM Grounding)
 
 以网格单元格(「点击 C3」)而非原始像素引用屏幕区域。完整参考:[`docs/source/Zh/doc/new_features/v159_features_doc.rst`](../docs/source/Zh/doc/new_features/v159_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 剪貼簿檔案拖放清單(CF_HDROP)
+
+把一份檔案清單放上剪貼簿,可直接貼進 Explorer。完整參考:[`docs/source/Zh/doc/new_features/v160_features_doc.rst`](../docs/source/Zh/doc/new_features/v160_features_doc.rst)。
+
+- **`build_dropfiles` / `parse_dropfiles` / `set_clipboard_files` / `get_clipboard_files`**(`AC_set_clipboard_files`、`AC_get_clipboard_files`):剪貼簿原本能承載文字、影像與(透過 `rich_clipboard`)HTML,卻從未支援*檔案清單*——也就是 Explorer 讀取以進行真正檔案複製的 `CF_HDROP` 內容。建構它相當瑣碎(20 位元組 `DROPFILES` 標頭 + 雙重 null 結尾的 UTF-16 路徑清單 + `pFiles` 位移)。本功能把封裝獨立為純粹、可完整測試的 `build_dropfiles` / `parse_dropfiles` 位元組函式,其上再疊加僅限 Windows 的 `set`/`get_clipboard_files` 薄包裝——與 `rich_clipboard` 處理 `CF_HTML` 的拆分方式相同。不匯入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 粗粒度標籤螢幕網格(VLM Grounding)
 
 以網格儲存格(「點擊 C3」)而非原始像素引用螢幕區域。完整參考:[`docs/source/Zh/doc/new_features/v159_features_doc.rst`](../docs/source/Zh/doc/new_features/v159_features_doc.rst)。

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Clipboard File-Drop List (CF_HDROP)
+
+Put a list of files on the clipboard, ready to paste into Explorer. Full reference: [`docs/source/Eng/doc/new_features/v160_features_doc.rst`](docs/source/Eng/doc/new_features/v160_features_doc.rst).
+
+- **`build_dropfiles` / `parse_dropfiles` / `set_clipboard_files` / `get_clipboard_files`** (`AC_set_clipboard_files`, `AC_get_clipboard_files`): the clipboard carried text, images and (via `rich_clipboard`) HTML, but never a *file list* — the `CF_HDROP` payload Explorer reads to paste files as a real copy. Building it is fiddly (20-byte `DROPFILES` header + double-null-terminated UTF-16 path list + `pFiles` offset). This isolates the packing into pure, fully testable `build_dropfiles` / `parse_dropfiles` byte functions, with thin Windows-only `set`/`get_clipboard_files` wrappers on top — the same split `rich_clipboard` uses for `CF_HTML`. No `PySide6`.
+
 ## What's new (2026-06-23) — Coarse Labelled Screen Grid (VLM Grounding)
 
 Refer to screen regions as grid cells ("click C3") instead of raw pixels. Full reference: [`docs/source/Eng/doc/new_features/v159_features_doc.rst`](docs/source/Eng/doc/new_features/v159_features_doc.rst).

--- a/docs/source/Eng/doc/new_features/v160_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v160_features_doc.rst
@@ -1,0 +1,44 @@
+Clipboard File-Drop List (CF_HDROP)
+===================================
+
+The clipboard layer carried text and images, and ``rich_clipboard`` added HTML, but the
+framework could never put a *list of files* on the clipboard — the ``CF_HDROP`` payload
+Explorer reads when you copy files and ``Ctrl+V`` them elsewhere as a real file copy.
+Building that blob is fiddly: a fixed 20-byte ``DROPFILES`` header followed by a
+double-null-terminated (UTF-16 by default) path list, with the header's ``pFiles`` offset
+pointing at the list. ``clipboard_files`` isolates that error-prone packing.
+
+The packing lives in pure, fully unit-testable ``build_dropfiles`` / ``parse_dropfiles``
+byte functions (no device, any platform), with thin Windows-only ``set_clipboard_files`` /
+``get_clipboard_files`` wrappers on top — the same split ``rich_clipboard`` uses for
+``CF_HTML``. The pure functions import no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import (build_dropfiles, parse_dropfiles,
+                                 set_clipboard_files, get_clipboard_files)
+
+    # put two files on the clipboard, ready to paste into Explorer (Windows)
+    set_clipboard_files([r"C:\reports\q1.pdf", r"C:\reports\q2.pdf"])
+    print(get_clipboard_files())
+
+    # the byte layer is testable without a clipboard at all
+    blob = build_dropfiles([r"C:\a\one.txt"], point=(10, 20))
+    assert parse_dropfiles(blob)["paths"] == [r"C:\a\one.txt"]
+
+``build_dropfiles(paths, *, point=(0, 0), wide=True, non_client=False)`` returns the raw
+``DROPFILES`` bytes; ``parse_dropfiles`` reverses it into
+``{paths, point, wide, non_client}``. ``set_clipboard_files`` / ``get_clipboard_files`` put
+and read the list via the Windows clipboard (``get`` returns ``None`` when no file list is
+present).
+
+Executor commands
+-----------------
+
+``AC_set_clipboard_files`` (``paths`` → ``{set, count}``) and ``AC_get_clipboard_files``
+(→ ``{found, paths}``). They are exposed as the MCP tools ``ac_set_clipboard_files`` /
+``ac_get_clipboard_files`` and as Script Builder commands **Set Clipboard Files** /
+**Get Clipboard Files** under **Data**.

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -182,6 +182,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v157_features_doc
    doc/new_features/v158_features_doc
    doc/new_features/v159_features_doc
+   doc/new_features/v160_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/doc/new_features/v160_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v160_features_doc.rst
@@ -1,0 +1,42 @@
+剪貼簿檔案拖放清單(CF_HDROP)
+==============================
+
+剪貼簿層原本能承載文字與影像,``rich_clipboard`` 又加入了 HTML,但框架始終無法把一份
+*檔案清單*放上剪貼簿——也就是當你複製檔案後在他處 ``Ctrl+V`` 進行真正的檔案複製時,
+Explorer 讀取的 ``CF_HDROP`` 內容。建構這個位元組區塊相當瑣碎:一個固定 20 位元組的
+``DROPFILES`` 標頭,後接以雙重 null 結尾(預設 UTF-16)的路徑清單,且標頭的 ``pFiles``
+位移需指向該清單。``clipboard_files`` 將這段容易出錯的封裝獨立出來。
+
+封裝邏輯位於純粹、可完整單元測試的 ``build_dropfiles`` / ``parse_dropfiles`` 位元組函式
+(不需裝置、任何平台皆可),其上再疊加僅限 Windows 的 ``set_clipboard_files`` /
+``get_clipboard_files`` 薄包裝——與 ``rich_clipboard`` 處理 ``CF_HTML`` 的拆分方式相同。
+純函式不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import (build_dropfiles, parse_dropfiles,
+                                 set_clipboard_files, get_clipboard_files)
+
+    # 將兩個檔案放上剪貼簿,可貼進 Explorer(Windows)
+    set_clipboard_files([r"C:\reports\q1.pdf", r"C:\reports\q2.pdf"])
+    print(get_clipboard_files())
+
+    # 位元組層完全不需剪貼簿即可測試
+    blob = build_dropfiles([r"C:\a\one.txt"], point=(10, 20))
+    assert parse_dropfiles(blob)["paths"] == [r"C:\a\one.txt"]
+
+``build_dropfiles(paths, *, point=(0, 0), wide=True, non_client=False)`` 回傳原始
+``DROPFILES`` 位元組;``parse_dropfiles`` 將其還原為 ``{paths, point, wide, non_client}``。
+``set_clipboard_files`` / ``get_clipboard_files`` 透過 Windows 剪貼簿寫入與讀取該清單
+(無檔案清單時 ``get`` 回傳 ``None``)。
+
+執行器指令
+----------
+
+``AC_set_clipboard_files``(``paths`` → ``{set, count}``)與 ``AC_get_clipboard_files``
+(→ ``{found, paths}``)。兩者以 MCP 工具 ``ac_set_clipboard_files`` /
+``ac_get_clipboard_files`` 及 Script Builder 指令 **Set Clipboard Files** /
+**Get Clipboard Files**(位於 **Data** 分類下)形式提供。

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -182,6 +182,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v157_features_doc
    doc/new_features/v158_features_doc
    doc/new_features/v159_features_doc
+   doc/new_features/v160_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -347,6 +347,10 @@ from je_auto_control.utils.locator_chain import Candidates, from_boxes
 from je_auto_control.utils.rich_clipboard import (
     build_cf_html, get_clipboard_html, parse_cf_html, set_clipboard_html,
 )
+# Clipboard file-drop list (CF_HDROP): pure DROPFILES packing + Win32 set/get
+from je_auto_control.utils.clipboard_files import (
+    build_dropfiles, get_clipboard_files, parse_dropfiles, set_clipboard_files,
+)
 # Colour-histogram fingerprint & change detection (illumination-robust)
 from je_auto_control.utils.img_histogram import (
     compare_histograms, histogram_changed, image_histogram,
@@ -1259,6 +1263,10 @@ __all__ = [
     "parse_cf_html",
     "get_clipboard_html",
     "set_clipboard_html",
+    "build_dropfiles",
+    "parse_dropfiles",
+    "set_clipboard_files",
+    "get_clipboard_files",
     "image_histogram",
     "compare_histograms",
     "histogram_changed",

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -1245,6 +1245,18 @@ def _add_misc_specs(specs: List[CommandSpec]) -> None:
         description="Read the clipboard's HTML fragment (CF_HTML, Windows).",
     ))
     specs.append(CommandSpec(
+        "AC_set_clipboard_files", "Data", "Set Clipboard Files",
+        fields=(
+            FieldSpec("paths", FieldType.STRING,
+                      placeholder='["C:\\\\a\\\\one.txt", "C:\\\\b\\\\two.png"]'),
+        ),
+        description="Put a file-drop list on the clipboard (CF_HDROP, Windows).",
+    ))
+    specs.append(CommandSpec(
+        "AC_get_clipboard_files", "Data", "Get Clipboard Files",
+        description="Read the clipboard's file-drop list (CF_HDROP, Windows).",
+    ))
+    specs.append(CommandSpec(
         "AC_watchdog_add", "Flow", "Watchdog: Add Popup Rule",
         fields=(
             FieldSpec("title", FieldType.STRING),

--- a/je_auto_control/utils/clipboard_files/__init__.py
+++ b/je_auto_control/utils/clipboard_files/__init__.py
@@ -1,0 +1,9 @@
+"""Clipboard file-drop list (CF_HDROP): pure DROPFILES packing + Win32 set/get."""
+from je_auto_control.utils.clipboard_files.clipboard_files import (
+    build_dropfiles, get_clipboard_files, parse_dropfiles, set_clipboard_files,
+)
+
+__all__ = [
+    "build_dropfiles", "parse_dropfiles",
+    "set_clipboard_files", "get_clipboard_files",
+]

--- a/je_auto_control/utils/clipboard_files/clipboard_files.py
+++ b/je_auto_control/utils/clipboard_files/clipboard_files.py
@@ -1,0 +1,108 @@
+"""Clipboard file-drop list (Windows ``CF_HDROP`` / ``DROPFILES``).
+
+The clipboard layer carries text and images, and ``rich_clipboard`` added HTML, but the
+framework could never put a *list of files* on the clipboard — the thing Explorer reads
+when you copy files and ``Ctrl+V`` them elsewhere (a ``CF_HDROP`` drop). Building that
+blob is fiddly byte work: a fixed ``DROPFILES`` header followed by a double-null-terminated
+(optionally wide) path list, with the header's ``pFiles`` offset pointing at the list.
+
+This isolates that error-prone packing into pure, fully unit-testable ``build_dropfiles`` /
+``parse_dropfiles`` byte functions (no device needed), with thin Windows-only
+``set_clipboard_files`` / ``get_clipboard_files`` wrappers on top — the same split
+``rich_clipboard`` uses for ``CF_HTML``. The pure functions import no ``PySide6`` and run
+on any platform; only the clipboard wrappers touch Win32.
+"""
+import struct
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+_CF_HDROP = 15
+_GMEM_MOVEABLE = 0x0002
+_HEADER_SIZE = 20  # DROPFILES: pFiles + pt.x + pt.y + fNC + fWide (5 x DWORD)
+
+
+def build_dropfiles(paths: Sequence[str], *, point: Tuple[int, int] = (0, 0),
+                    wide: bool = True, non_client: bool = False) -> bytes:
+    """Pack ``paths`` into a ``CF_HDROP`` / ``DROPFILES`` byte blob.
+
+    ``point`` is the drop coordinate, ``wide`` selects UTF-16LE (the modern default)
+    over single-byte paths, and ``non_client`` sets the ``fNC`` flag. The path list is
+    double-null terminated as the format requires.
+    """
+    if not paths:
+        raise ValueError("at least one path is required")
+    header = struct.pack("<5I", _HEADER_SIZE, int(point[0]), int(point[1]),
+                         1 if non_client else 0, 1 if wide else 0)
+    listing = "".join(f"{path}\0" for path in paths) + "\0"
+    body = listing.encode("utf-16-le" if wide else "latin-1")
+    return header + body
+
+
+def parse_dropfiles(data: bytes) -> Dict[str, Any]:
+    """Unpack a ``CF_HDROP`` / ``DROPFILES`` blob into ``{paths, point, wide, non_client}``."""
+    if len(data) < _HEADER_SIZE:
+        raise ValueError("data too short for a DROPFILES header")
+    p_files, x, y, f_nc, f_wide = struct.unpack("<5I", data[:_HEADER_SIZE])
+    wide = bool(f_wide)
+    body = data[p_files:]
+    text = body.decode("utf-16-le" if wide else "latin-1")
+    paths = [part for part in text.split("\0") if part]
+    return {"paths": paths, "point": [x, y], "wide": wide,
+            "non_client": bool(f_nc)}
+
+
+def set_clipboard_files(paths: Sequence[str], *, point: Tuple[int, int] = (0, 0),
+                        non_client: bool = False) -> None:
+    """Put ``paths`` on the clipboard as a ``CF_HDROP`` file-drop list (Windows)."""
+    blob = build_dropfiles(paths, point=point, wide=True, non_client=non_client)
+    _win_set_hdrop(blob)
+
+
+def get_clipboard_files() -> Optional[List[str]]:
+    """Return the file paths on the clipboard as a ``CF_HDROP`` list, or ``None``."""
+    blob = _win_get_hdrop()
+    if blob is None:
+        return None
+    return parse_dropfiles(blob)["paths"]
+
+
+def _win_set_hdrop(blob: bytes) -> None:
+    import ctypes
+    from ctypes import wintypes
+    user32, kernel32 = ctypes.windll.user32, ctypes.windll.kernel32
+    kernel32.GlobalAlloc.restype = wintypes.HGLOBAL
+    kernel32.GlobalLock.restype = ctypes.c_void_p
+    if not user32.OpenClipboard(None):
+        raise RuntimeError("OpenClipboard failed")
+    try:
+        user32.EmptyClipboard()
+        handle = kernel32.GlobalAlloc(_GMEM_MOVEABLE, len(blob))
+        if not handle:
+            raise RuntimeError("GlobalAlloc failed")
+        pointer = kernel32.GlobalLock(handle)
+        ctypes.memmove(pointer, blob, len(blob))
+        kernel32.GlobalUnlock(handle)
+        if not user32.SetClipboardData(_CF_HDROP, handle):
+            raise RuntimeError("SetClipboardData(CF_HDROP) failed")
+    finally:
+        user32.CloseClipboard()
+
+
+def _win_get_hdrop() -> Optional[bytes]:
+    import ctypes
+    from ctypes import wintypes
+    user32, kernel32 = ctypes.windll.user32, ctypes.windll.kernel32
+    user32.GetClipboardData.restype = wintypes.HANDLE
+    kernel32.GlobalLock.restype = ctypes.c_void_p
+    if not user32.OpenClipboard(None):
+        raise RuntimeError("OpenClipboard failed")
+    try:
+        handle = user32.GetClipboardData(_CF_HDROP)
+        if not handle:
+            return None
+        pointer = kernel32.GlobalLock(handle)
+        size = kernel32.GlobalSize(handle)
+        data = ctypes.string_at(pointer, size)
+        kernel32.GlobalUnlock(handle)
+        return data
+    finally:
+        user32.CloseClipboard()

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3751,6 +3751,24 @@ def _get_clipboard_html() -> Dict[str, Any]:
     return {"found": html is not None, "html": html}
 
 
+def _set_clipboard_files(paths: Any) -> Dict[str, Any]:
+    """Adapter: put a file-drop list (CF_HDROP) on the clipboard (Windows)."""
+    import json
+    from je_auto_control.utils.clipboard_files import set_clipboard_files
+    if isinstance(paths, str):
+        paths = json.loads(paths) if paths.strip().startswith("[") else [paths]
+    paths = [str(p) for p in paths]
+    set_clipboard_files(paths)
+    return {"set": True, "count": len(paths)}
+
+
+def _get_clipboard_files() -> Dict[str, Any]:
+    """Adapter: read the clipboard's file-drop list (CF_HDROP) (Windows)."""
+    from je_auto_control.utils.clipboard_files import get_clipboard_files
+    paths = get_clipboard_files()
+    return {"found": paths is not None, "paths": paths or []}
+
+
 def _image_histogram(source: Any = None, bins: Any = 32, space: str = "hsv",
                      region: Any = None) -> Dict[str, Any]:
     """Adapter: per-channel colour histogram of an image / the screen."""
@@ -5786,6 +5804,8 @@ class Executor:
             "AC_locate_chain": _locate_chain,
             "AC_set_clipboard_html": _set_clipboard_html,
             "AC_get_clipboard_html": _get_clipboard_html,
+            "AC_set_clipboard_files": _set_clipboard_files,
+            "AC_get_clipboard_files": _get_clipboard_files,
             "AC_image_histogram": _image_histogram,
             "AC_histogram_changed": _histogram_changed,
             "AC_changed_regions": _changed_regions,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3086,6 +3086,31 @@ def rich_clipboard_tools() -> List[MCPTool]:
     ]
 
 
+def clipboard_files_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_set_clipboard_files",
+            description=("Put a file-drop list on the clipboard as CF_HDROP so the "
+                         "files can be pasted (Ctrl+V) into Explorer / apps as a real "
+                         "file copy (Windows). 'paths' is a list of absolute paths. "
+                         "Returns {set, count}."),
+            input_schema=schema({
+                "paths": {"type": "array", "items": {"type": "string"}}},
+                required=["paths"]),
+            handler=h.set_clipboard_files,
+            annotations=SIDE_EFFECT_ONLY,
+        ),
+        MCPTool(
+            name="ac_get_clipboard_files",
+            description=("Read the clipboard's file-drop list (CF_HDROP, Windows). "
+                         "Returns {found, paths}."),
+            input_schema=schema({}, required=[]),
+            handler=h.get_clipboard_files,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def img_histogram_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -7020,7 +7045,8 @@ ALL_FACTORIES = (
     window_layout_tools, window_arrange_tools, preprocess_tools,
     monitor_layout_tools, actionability_tools, element_parse_tools,
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
-    locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
+    locator_chain_tools, rich_clipboard_tools, clipboard_files_tools,
+    img_histogram_tools,
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
     perceptual_diff_tools, window_geometry_tools, cua_action_tools,
     observation_tools, action_grounding_tools, agent_replay_tools,

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2276,6 +2276,16 @@ def get_clipboard_html():
     return _get_clipboard_html()
 
 
+def set_clipboard_files(paths):
+    from je_auto_control.utils.executor.action_executor import _set_clipboard_files
+    return _set_clipboard_files(paths)
+
+
+def get_clipboard_files():
+    from je_auto_control.utils.executor.action_executor import _get_clipboard_files
+    return _get_clipboard_files()
+
+
 def image_histogram(source=None, bins=32, space="hsv", region=None):
     from je_auto_control.utils.executor.action_executor import _image_histogram
     return _image_histogram(source, bins, space, region)

--- a/test/unit_test/headless/test_clipboard_files_batch.py
+++ b/test/unit_test/headless/test_clipboard_files_batch.py
@@ -1,0 +1,64 @@
+"""Headless tests for CF_HDROP DROPFILES packing (pure byte math; Win32 skipped)."""
+import struct
+
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.clipboard_files import build_dropfiles, parse_dropfiles
+
+
+def test_round_trip_wide():
+    paths = ["C:\\a\\one.txt", "C:\\b\\twö.png"]  # non-ASCII to exercise UTF-16
+    blob = build_dropfiles(paths, point=(12, 34))
+    parsed = parse_dropfiles(blob)
+    assert parsed["paths"] == paths
+    assert parsed["point"] == [12, 34]
+    assert parsed["wide"] is True
+    assert parsed["non_client"] is False
+
+
+def test_header_layout_and_double_null():
+    blob = build_dropfiles(["a.txt"])
+    p_files, x, y, f_nc, f_wide = struct.unpack("<5I", blob[:20])
+    assert p_files == 20  # list begins right after the 20-byte header
+    assert (x, y, f_nc, f_wide) == (0, 0, 0, 1)
+    # wide list ends with two UTF-16 nulls (path-null + list-null)
+    assert blob.endswith(b"\x00\x00\x00\x00")
+
+
+def test_non_wide_uses_single_byte():
+    blob = build_dropfiles(["ab.txt"], wide=False)
+    assert struct.unpack("<5I", blob[:20])[4] == 0
+    parsed = parse_dropfiles(blob)
+    assert parsed["paths"] == ["ab.txt"] and parsed["wide"] is False
+
+
+def test_point_and_non_client_flags():
+    parsed = parse_dropfiles(build_dropfiles(["x"], point=(5, 9), non_client=True))
+    assert parsed["point"] == [5, 9] and parsed["non_client"] is True
+
+
+def test_empty_paths_and_short_data_raise():
+    with pytest.raises(ValueError):
+        build_dropfiles([])
+    with pytest.raises(ValueError):
+        parse_dropfiles(b"\x00\x00")
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_set_clipboard_files", "AC_get_clipboard_files"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_set_clipboard_files", "ac_get_clipboard_files"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_set_clipboard_files", "AC_get_clipboard_files"} <= specs
+
+
+def test_facade_exports():
+    for name in ("build_dropfiles", "parse_dropfiles",
+                 "set_clipboard_files", "get_clipboard_files"):
+        assert hasattr(ac, name) and name in ac.__all__


### PR DESCRIPTION
## Summary
Adds the ability to put a **list of files** on the clipboard as `CF_HDROP` — the payload Explorer reads when you copy files and `Ctrl+V` them elsewhere as a real file copy. The clipboard layer carried text and images, and `rich_clipboard` added HTML, but never a file list; `rich_clipboard` explicitly deferred `CF_HDROP` as fiddly OLE work.

Building the blob is the error-prone part: a fixed 20-byte `DROPFILES` header followed by a double-null-terminated (UTF-16 by default) path list, with the header's `pFiles` offset pointing at the list. This isolates that packing into pure, fully unit-testable `build_dropfiles` / `parse_dropfiles` byte functions (no device, any platform), with thin Windows-only `set_clipboard_files` / `get_clipboard_files` wrappers on top — the same split `rich_clipboard` uses for `CF_HTML`. Qt-free.

## Layers
- **Core**: `utils/clipboard_files/` — `build_dropfiles`, `parse_dropfiles`, `set_clipboard_files`, `get_clipboard_files`.
- **Facade**: re-exported from `je_auto_control` + `__all__`.
- **Executor**: `AC_set_clipboard_files` (`{set, count}`) / `AC_get_clipboard_files` (`{found, paths}`).
- **MCP**: `ac_set_clipboard_files` (side-effect) / `ac_get_clipboard_files` (read-only).
- **Script Builder**: **Set Clipboard Files** / **Get Clipboard Files** under **Data**.
- **Docs**: v160 EN + Zh + toctree.
- **Changelog**: root EN + zh-TW + zh-CN.

## Tests
`test/unit_test/headless/test_clipboard_files_batch.py` — wide round-trip (incl. non-ASCII UTF-16), header layout + double-null terminator, single-byte (non-wide) path, point/non-client flags, empty-paths + short-data raise, full wiring + facade exports. 7 passed; the Win32 set/get path is platform-guarded (byte core covers it). ruff / bandit / radon / float-scan / Qt-free all clean.