### PR TITLE
Release: round-12 MED tier (16 features, v145-v160)

### DIFF
--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 一维条码解码
+
+从屏幕或图像读取 EAN / UPC / Code-128 条码。完整参考:[`docs/source/Zh/doc/new_features/v157_features_doc.rst`](../docs/source/Zh/doc/new_features/v157_features_doc.rst)。
+
+- **`read_barcodes`**(`AC_read_barcodes`):框架已能解码 QR Code(`read_qr`),但缺少能读取*一维*条码(EAN-13/8、UPC-A、Code-128)的功能——这些正是商品、库存标签与物流面单上最常见的条码。本功能通过 OpenCV 的 `cv2.barcode.BarcodeDetector` 解码,每个条码返回 `{text, type, points}`。解码步骤为可注入接缝(默认调用 OpenCV;测试可传入自己的 `decoder`),因此可完整无头测试且能优雅降级——若 OpenCV 编译时未含 `barcode` 模块,返回 `[]` 而非抛出异常。重用共用的 `visual_match` haystack 加载器;不导入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 加权候选评分
 
 以信心分数排序模棱两可的元素候选。完整参考:[`docs/source/Zh/doc/new_features/v156_features_doc.rst`](../docs/source/Zh/doc/new_features/v156_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 加权候选评分
+
+以信心分数排序模棱两可的元素候选。完整参考:[`docs/source/Zh/doc/new_features/v156_features_doc.rst`](../docs/source/Zh/doc/new_features/v156_features_doc.rst)。
+
+- **`score_candidates` / `best_candidate`**(`AC_score_candidates`、`AC_best_candidate`):`anchor_locator` 是单一关系 + 距离排序、`ab_locator` 依耗时竞赛整个策略——两者都不以*加权*混合(角色匹配 + 模糊名称相似度 + 锚点邻近 + 启用状态)排序模棱候选。本功能返回最佳优先的 `ScoredCandidate` 并含 `matched_on` 明细;名称相似度可注入(默认 `fuzzy_ratio`,重用——不新增字符串距离代码)。纯标准库,作用于元素字典;在多个框都可能是目标时驱动自我修复 / grounding。可无头测试。
+
 ## 本次更新 (2026-06-23) — 几何感知的元素差异与稳定 ID
 
 以重叠跨帧追踪元素,并给予稳定 ID。完整参考:[`docs/source/Zh/doc/new_features/v155_features_doc.rst`](../docs/source/Zh/doc/new_features/v155_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 色彩直方图指纹与变化检测
+
+判断画面在光照 / 缩放下是否仍是「同一个」。完整参考:[`docs/source/Zh/doc/new_features/v145_features_doc.rst`](../docs/source/Zh/doc/new_features/v145_features_doc.rst)。
+
+- **`image_histogram` / `compare_histograms` / `histogram_changed`**(`AC_image_histogram`、`AC_histogram_changed`):`image_dedup` 的感知哈希是空间性的(对颜色/主题脆弱)、`color_stats` 只有单一颜色。归一化色彩直方图是耐光照/缩放的「同一画面、还是调色板变了?」信号(主题切换、重载、旋转横幅)。`image_histogram` 返回逐通道直方图(`hsv`/`rgb`/`gray`);`compare_histograms` 提供 correlation/chisqr/intersection/bhattacharyya;`histogram_changed` 比较参考与实际屏幕。可注入图像 → 无头可测;OpenCV 核心(`cv2.calcHist`/`compareHist`)。
+
 ## 本次更新 (2026-06-23) — 丰富剪贴板(HTML / CF_HTML)
 
 把*格式化*的 HTML 复制粘贴到 Word / Outlook。完整参考:[`docs/source/Zh/doc/new_features/v144_features_doc.rst`](../docs/source/Zh/doc/new_features/v144_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 几何感知的元素差异与稳定 ID
+
+以重叠跨帧追踪元素,并给予稳定 ID。完整参考:[`docs/source/Zh/doc/new_features/v155_features_doc.rst`](../docs/source/Zh/doc/new_features/v155_features_doc.rst)。
+
+- **`match_elements` / `assign_stable_ids`**(`AC_match_elements`、`AC_assign_stable_ids`):`diff_snapshots` 以 `(role, name)` 作识别——无法比对改名但未移动或移动了的控制项,也无法跨帧给持久 ID。本功能以 IoU 比对元素框(沿用 `element_parse.iou`):`match_elements` 返回 `{matched, added, removed}`;`assign_stable_ids` 从 `prior` 帧延续每个元素的 `id`(移动的按钮保留 id、新增者取得新 id)——让 agent 能跨回合可靠地引用「element 7」。纯标准库、可无头测试。
+
 ## 本次更新 (2026-06-23) — 可携式 Agent 轨迹记录(录制与重播)
 
 记录 agent 的观测→动作步骤并重播。完整参考:[`docs/source/Zh/doc/new_features/v154_features_doc.rst`](../docs/source/Zh/doc/new_features/v154_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 旋转与缩放容忍的模板匹配
+
+不只缩放,还能找到旋转或倾斜的模板。完整参考:[`docs/source/Zh/doc/new_features/v158_features_doc.rst`](../docs/source/Zh/doc/new_features/v158_features_doc.rst)。
+
+- **`match_rotated` / `match_rotated_all` / `scale_space`**(`AC_match_rotated`、`AC_match_rotated_all`):`match_template` 只扫描*缩放*且假设轴对齐——OpenCV 的 `matchTemplate` 不具旋转不变性,因此倾斜的控件、旋转的图标,或转到不同角度的刻度盘都会匹配失败。本功能扫描 `angles`(每个以 `cv2.warpAffine` 变形)并与 `np.linspace` 缩放空间交叉,返回相关性最高、且带有还原 `scale` + `angle` 的 `RotatedMatch`(`*_all` 版本以 NMS 合并相邻角度 / 缩放)。重用 `visual_match` 的加载器 / resize / 方法表 / NMS——不重复任何匹配或几何代码。`haystack` 可注入;可无头测试;不导入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 一维条码解码
 
 从屏幕或图像读取 EAN / UPC / Code-128 条码。完整参考:[`docs/source/Zh/doc/new_features/v157_features_doc.rst`](../docs/source/Zh/doc/new_features/v157_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 动作前接地防护
+
+拒绝越界点击;把接近偏离者吸附到真正的元素。完整参考:[`docs/source/Zh/doc/new_features/v153_features_doc.rst`](../docs/source/Zh/doc/new_features/v153_features_doc.rst)。
+
+- **`validate_action` / `snap_to_element` / `in_bounds`**(`AC_validate_action`):`guardrail` 扫文字、`loop_guard` 检测循环——两者都不在派发前验证坐标动作,所以幻觉 `(9999,-5)` 点击会打到空处、偏 5px 的点击会错过。本功能拒绝屏幕外坐标,并在提供 `targets` 时把接近偏离者吸附到最近元素中心,返回 `{ok, reason, snapped}`。纯标准库几何,作用于元素字典;执行器 `screen` 默认为实际屏幕。可无头测试;接在 agent 循环派发之前。
+
 ## 本次更新 (2026-06-23) — 符记预算内的无障碍文字观测
 
 把无障碍树转成 VLM 可操作的已编号文字区块。完整参考:[`docs/source/Zh/doc/new_features/v152_features_doc.rst`](../docs/source/Zh/doc/new_features/v152_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 软性断言(汇整所有失败)
+
+验证很多项,一次报告每一个失败。完整参考:[`docs/source/Zh/doc/new_features/v148_features_doc.rst`](../docs/source/Zh/doc/new_features/v148_features_doc.rst)。
+
+- **`SoftAssertions`**(`AC_soft_assert`):`assert_all` 接受事先建好的规格列表——没有可随处调用 `check()`、并在区块退出时一次抛出全部的作用域累加器(JUnit5 `assertAll` / Playwright `expect.soft`)。`with SoftAssertions() as soft: soft.check(...)` 记录通过/失败(区块中永不抛出、返回布尔值可分支),退出时一次抛出列出每个失败——且永不遮蔽已在传播的异常。执行器命令汇整 JSON `checks` 列表(eq/ne/gt/lt/contains/truthy)。纯标准库、可无头测试。
+
 ## 本次更新 (2026-06-23) — 窗口 Z-order(置顶 / 最前 / 最后)
 
 把窗口钉在最上层、移到最前、或推到后面。完整参考:[`docs/source/Zh/doc/new_features/v147_features_doc.rst`](../docs/source/Zh/doc/new_features/v147_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 符记预算内的无障碍文字观测
+
+把无障碍树转成 VLM 可操作的已编号文字区块。完整参考:[`docs/source/Zh/doc/new_features/v152_features_doc.rst`](../docs/source/Zh/doc/new_features/v152_features_doc.rst)。
+
+- **`serialize_observation` / `observation_index` / `flatten_tree`**(`AC_serialize_observation`、`AC_observation_index`):`describe_screen` 给角色*数量* + 平面标签列表——没有稳定索引、没有 `[12] button "Submit" @(x,y)` 行、没有视口裁切、没有符记预算。本功能把(嵌套)元素树扁平化为仅互动项、裁切到视口、依阅读顺序排序、上限 `max_elements`、指派稳定 `index`,并渲染模型可操作的行(「click [12]」)。纯标准库,作用于元素字典;与 `fuse_elements`/`set_of_marks` 搭配。可无头测试。
+
 ## 本次更新 (2026-06-23) — 标准化 Computer-Use 动作结构
 
 把 Anthropic / OpenAI agent 动作桥接到 AutoControl 命令。完整参考:[`docs/source/Zh/doc/new_features/v151_features_doc.rst`](../docs/source/Zh/doc/new_features/v151_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 窗口 Z-order(置顶 / 最前 / 最后)
+
+把窗口钉在最上层、移到最前、或推到后面。完整参考:[`docs/source/Zh/doc/new_features/v147_features_doc.rst`](../docs/source/Zh/doc/new_features/v147_features_doc.rst)。
+
+- **`set_topmost` / `bring_to_front` / `send_to_back` / `plan_zorder`**(`AC_set_topmost`、`AC_bring_to_front`、`AC_send_to_back`):原始 `set_window_position` 存在但未在 facade、无标题包装也无 topmost 语意——缺少标准 RPA 的「置顶」。`plan_zorder` 是纯动作→`SetWindowPos` 常数查找(可无头测试);以标题操作的设定器透过可注入 driver(`snap_window` 接缝模式)套用,默认为 Win32。
+
 ## 本次更新 (2026-06-23) — 局部动态 / 活动检测
 
 找出两帧之间哪些子区域在动。完整参考:[`docs/source/Zh/doc/new_features/v146_features_doc.rst`](../docs/source/Zh/doc/new_features/v146_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 可携式 Agent 轨迹记录(录制与重播)
+
+记录 agent 的观测→动作步骤并重播。完整参考:[`docs/source/Zh/doc/new_features/v154_features_doc.rst`](../docs/source/Zh/doc/new_features/v154_features_doc.rst)。
+
+- **`record_step` / `to_jsonl` / `from_jsonl` / `replay_trace`**(`AC_replay_trace`):`agent_trace` 记录 OTel span(观测性)、`trajectory_eval` 只评分、`semantic_recording` 重播人类宏——都不是可重播的观测→动作转录。本功能是 OmniTool 风格的 `{step, observation, action, result}` JSONL,加确定性重播驱动器(可注入 `runner`、无需即时模型)。执行器命令透过执行器重播每一步的 AC 动作。纯标准库、可无头测试;可从 agent 执行建立回归 / 训练数据集。
+
 ## 本次更新 (2026-06-23) — 动作前接地防护
 
 拒绝越界点击;把接近偏离者吸附到真正的元素。完整参考:[`docs/source/Zh/doc/new_features/v153_features_doc.rst`](../docs/source/Zh/doc/new_features/v153_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 粗粒度标签屏幕网格(VLM Grounding)
+
+以网格单元格(「点击 C3」)而非原始像素引用屏幕区域。完整参考:[`docs/source/Zh/doc/new_features/v159_features_doc.rst`](../docs/source/Zh/doc/new_features/v159_features_doc.rst)。
+
+- **`grid_cells` / `cell_for_point` / `point_for_cell`**(`AC_grid_cells`、`AC_cell_for_point`、`AC_point_for_cell`):VLM grounding 在模型指名粗粒度单元格时,远比输出容易幻觉的像素坐标更可靠。本功能在屏幕(或 `region`)上铺设 `rows`x`cols` 网格,以电子表格风格标记每个单元格(左上 `A1`,超过 `Z` → `AA`),并双向对应——点 → 包含的单元格、指名单元格 → 中心点(可直接点击)。纯标准库几何;唯一设备相关的路径是读取实时屏幕尺寸的默认行为,因此每个函数都可通过明确 `region` 无头测试。不导入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 旋转与缩放容忍的模板匹配
 
 不只缩放,还能找到旋转或倾斜的模板。完整参考:[`docs/source/Zh/doc/new_features/v158_features_doc.rst`](../docs/source/Zh/doc/new_features/v158_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 标准化 Computer-Use 动作结构
+
+把 Anthropic / OpenAI agent 动作桥接到 AutoControl 命令。完整参考:[`docs/source/Zh/doc/new_features/v151_features_doc.rst`](../docs/source/Zh/doc/new_features/v151_features_doc.rst)。
+
+- **`from_anthropic` / `from_openai_cua` / `to_ac_command` / `canonical_action`**(`AC_cua_command`):`tool_use_schema` 导出 AC_* 签章、`coordinate_space` 缩放——两者都不*正规化进来的动作载荷*。Anthropic 发出 `{action:"left_click", coordinate:[x,y]}`、OpenAI CUA 发出 `{type:"click", x, y, button}`;这些转接器把两者对应为标准动作再对应为可执行的 `[AC_*, params]`(含可选坐标空间 `scale`)。纯标准库、可无头测试;执行器命令对任一来源返回 `{canonical, command}`。
+
 ## 本次更新 (2026-06-23) — 窗口客户区几何
 
 不论标题栏 / 边框,点击窗口*内部*。完整参考:[`docs/source/Zh/doc/new_features/v150_features_doc.rst`](../docs/source/Zh/doc/new_features/v150_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 局部动态 / 活动检测
+
+找出两帧之间哪些子区域在动。完整参考:[`docs/source/Zh/doc/new_features/v146_features_doc.rst`](../docs/source/Zh/doc/new_features/v146_features_doc.rst)。
+
+- **`changed_regions` / `has_motion` / `activity_score`**(`AC_changed_regions`、`AC_has_motion`):`wait_until_screen_stable` 是布尔轮询、`ssim_changed_regions` 是结构性(忽略快速动态)、`diff_screenshots` 非活动区块。本功能是便宜的 absdiff 路径——对逐像素差做门槛、膨胀,返回移动区域方框(由大到小)、布尔值,以及移动像素比例。挑选安静区域或定位转圈动画。两个可注入帧 → 无头可测;沿用共用连通元件辅助;执行器中 `after` 默认为即时屏幕截取。
+
 ## 本次更新 (2026-06-23) — 色彩直方图指纹与变化检测
 
 判断画面在光照 / 缩放下是否仍是「同一个」。完整参考:[`docs/source/Zh/doc/new_features/v145_features_doc.rst`](../docs/source/Zh/doc/new_features/v145_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 窗口客户区几何
+
+不论标题栏 / 边框,点击窗口*内部*。完整参考:[`docs/source/Zh/doc/new_features/v150_features_doc.rst`](../docs/source/Zh/doc/new_features/v150_features_doc.rst)。
+
+- **`get_client_rect` / `client_point` / `frame_insets` / `client_to_screen`**(`AC_get_client_rect`、`AC_client_point`):`get_window_geometry` 只返回*外框*——没有客户区矩形、框边内缩运算或客户区→屏幕对应。`client_point("App", x, y)` 把内容相对点对应到屏幕,让点击不论外框都落在窗口内;`frame_insets` 报告边框 / 标题栏厚度。`frame_insets`/`client_to_screen` 是纯几何(可无头测试);`get_client_rect` 使用可注入的 Win32 读取器(`GetClientRect`+`ClientToScreen`)。
+
 ## 本次更新 (2026-06-23) — 感知式(YIQ)图像比对含反锯齿抑制
 
 会忽略反锯齿边缘的视觉回归比对。完整参考:[`docs/source/Zh/doc/new_features/v149_features_doc.rst`](../docs/source/Zh/doc/new_features/v149_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 剪贴板文件拖放列表(CF_HDROP)
+
+把一份文件列表放上剪贴板,可直接粘贴进 Explorer。完整参考:[`docs/source/Zh/doc/new_features/v160_features_doc.rst`](../docs/source/Zh/doc/new_features/v160_features_doc.rst)。
+
+- **`build_dropfiles` / `parse_dropfiles` / `set_clipboard_files` / `get_clipboard_files`**(`AC_set_clipboard_files`、`AC_get_clipboard_files`):剪贴板原本能承载文本、图像与(通过 `rich_clipboard`)HTML,却从未支持*文件列表*——也就是 Explorer 读取以进行真正文件复制的 `CF_HDROP` 内容。构建它相当繁琐(20 字节 `DROPFILES` 头 + 双重 null 结尾的 UTF-16 路径列表 + `pFiles` 偏移)。本功能把封装独立为纯粹、可完整测试的 `build_dropfiles` / `parse_dropfiles` 字节函数,其上再叠加仅限 Windows 的 `set`/`get_clipboard_files` 薄包装——与 `rich_clipboard` 处理 `CF_HTML` 的拆分方式相同。不导入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 粗粒度标签屏幕网格(VLM Grounding)
 
 以网格单元格(「点击 C3」)而非原始像素引用屏幕区域。完整参考:[`docs/source/Zh/doc/new_features/v159_features_doc.rst`](../docs/source/Zh/doc/new_features/v159_features_doc.rst)。

--- a/README/WHATS_NEW_zh-CN.md
+++ b/README/WHATS_NEW_zh-CN.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 感知式(YIQ)图像比对含反锯齿抑制
+
+会忽略反锯齿边缘的视觉回归比对。完整参考:[`docs/source/Zh/doc/new_features/v149_features_doc.rst`](../docs/source/Zh/doc/new_features/v149_features_doc.rst)。
+
+- **`perceptual_diff` / `assert_perceptual`**(`AC_perceptual_diff`):`image_difference` 计算原始逐通道差、`ssim_compare` 是整体分数——两者都未使用感知式度量也不忽略反锯齿(视觉比对误报的首要来源)。本功能在 YIQ 空间比较(pixelmatch 的色彩度量),并预设以形态学开运算移除单像素反锯齿细边差异,只计算实心变化(`include_aa=True` 保留)。返回 `{diff_pixels, diff_ratio, regions}`;`assert_perceptual` / `max_diff_ratio` 把关回归测试。可注入图像配对 → 无头可测(1px 细边 → 0、实心区块 → 计入)。
+
 ## 本次更新 (2026-06-23) — 软性断言(汇整所有失败)
 
 验证很多项,一次报告每一个失败。完整参考:[`docs/source/Zh/doc/new_features/v148_features_doc.rst`](../docs/source/Zh/doc/new_features/v148_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 色彩直方圖指紋與變化偵測
+
+判斷畫面在光照 / 縮放下是否仍是「同一個」。完整參考:[`docs/source/Zh/doc/new_features/v145_features_doc.rst`](../docs/source/Zh/doc/new_features/v145_features_doc.rst)。
+
+- **`image_histogram` / `compare_histograms` / `histogram_changed`**(`AC_image_histogram`、`AC_histogram_changed`):`image_dedup` 的感知雜湊是空間性的(對顏色/主題脆弱)、`color_stats` 只有單一顏色。正規化色彩直方圖是耐光照/縮放的「同一畫面、還是調色盤變了?」訊號(主題切換、重載、旋轉橫幅)。`image_histogram` 回傳逐通道直方圖(`hsv`/`rgb`/`gray`);`compare_histograms` 提供 correlation/chisqr/intersection/bhattacharyya;`histogram_changed` 比較參考與實際螢幕。可注入影像 → 無頭可測;OpenCV 核心(`cv2.calcHist`/`compareHist`)。
+
 ## 本次更新 (2026-06-23) — 豐富剪貼簿(HTML / CF_HTML)
 
 把*格式化*的 HTML 複製貼上到 Word / Outlook。完整參考:[`docs/source/Zh/doc/new_features/v144_features_doc.rst`](../docs/source/Zh/doc/new_features/v144_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 動作前接地防護
+
+拒絕越界點擊;把接近偏離者吸附到真正的元素。完整參考:[`docs/source/Zh/doc/new_features/v153_features_doc.rst`](../docs/source/Zh/doc/new_features/v153_features_doc.rst)。
+
+- **`validate_action` / `snap_to_element` / `in_bounds`**(`AC_validate_action`):`guardrail` 掃文字、`loop_guard` 偵測迴圈——兩者都不在派發前驗證座標動作,所以幻覺 `(9999,-5)` 點擊會打到空處、偏 5px 的點擊會錯過。本功能拒絕螢幕外座標,並在提供 `targets` 時把接近偏離者吸附到最近元素中心,回傳 `{ok, reason, snapped}`。純標準函式庫幾何,作用於元素字典;執行器 `screen` 預設為實際螢幕。可無頭測試;接在 agent 迴圈派發之前。
+
 ## 本次更新 (2026-06-23) — 符記預算內的無障礙文字觀測
 
 把無障礙樹轉成 VLM 可操作的已編號文字區塊。完整參考:[`docs/source/Zh/doc/new_features/v152_features_doc.rst`](../docs/source/Zh/doc/new_features/v152_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 粗粒度標籤螢幕網格(VLM Grounding)
+
+以網格儲存格(「點擊 C3」)而非原始像素引用螢幕區域。完整參考:[`docs/source/Zh/doc/new_features/v159_features_doc.rst`](../docs/source/Zh/doc/new_features/v159_features_doc.rst)。
+
+- **`grid_cells` / `cell_for_point` / `point_for_cell`**(`AC_grid_cells`、`AC_cell_for_point`、`AC_point_for_cell`):VLM grounding 在模型指名粗粒度儲存格時,遠比輸出容易幻覺的像素座標更可靠。本功能在螢幕(或 `region`)上鋪設 `rows`x`cols` 網格,以試算表風格標記每個儲存格(左上 `A1`,超過 `Z` → `AA`),並雙向對應——點 → 包含的儲存格、指名儲存格 → 中心點(可直接點擊)。純標準函式庫幾何;唯一裝置相依的路徑是讀取即時螢幕尺寸的預設行為,因此每個函式都可透過明確 `region` 無頭測試。不匯入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 旋轉與縮放容忍的樣板比對
 
 不只縮放,還能找到旋轉或傾斜的樣板。完整參考:[`docs/source/Zh/doc/new_features/v158_features_doc.rst`](../docs/source/Zh/doc/new_features/v158_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 可攜式 Agent 軌跡記錄(錄製與重播)
+
+記錄 agent 的觀測→動作步驟並重播。完整參考:[`docs/source/Zh/doc/new_features/v154_features_doc.rst`](../docs/source/Zh/doc/new_features/v154_features_doc.rst)。
+
+- **`record_step` / `to_jsonl` / `from_jsonl` / `replay_trace`**(`AC_replay_trace`):`agent_trace` 記錄 OTel span(觀測性)、`trajectory_eval` 只評分、`semantic_recording` 重播人類巨集——都不是可重播的觀測→動作轉錄。本功能是 OmniTool 風格的 `{step, observation, action, result}` JSONL,加決定性重播驅動器(可注入 `runner`、無需即時模型)。執行器命令透過執行器重播每一步的 AC 動作。純標準函式庫、可無頭測試;可從 agent 執行建立回歸 / 訓練資料集。
+
 ## 本次更新 (2026-06-23) — 動作前接地防護
 
 拒絕越界點擊;把接近偏離者吸附到真正的元素。完整參考:[`docs/source/Zh/doc/new_features/v153_features_doc.rst`](../docs/source/Zh/doc/new_features/v153_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 一維條碼解碼
+
+從螢幕或影像讀取 EAN / UPC / Code-128 條碼。完整參考:[`docs/source/Zh/doc/new_features/v157_features_doc.rst`](../docs/source/Zh/doc/new_features/v157_features_doc.rst)。
+
+- **`read_barcodes`**(`AC_read_barcodes`):框架已能解碼 QR Code(`read_qr`),但缺少能讀取*一維*條碼(EAN-13/8、UPC-A、Code-128)的功能——這些正是商品、庫存標籤與物流面單上最常見的條碼。本功能透過 OpenCV 的 `cv2.barcode.BarcodeDetector` 解碼,每個條碼回傳 `{text, type, points}`。解碼步驟為可注入接縫(預設呼叫 OpenCV;測試可傳入自己的 `decoder`),因此可完整無頭測試且能優雅降級——若 OpenCV 編譯時未含 `barcode` 模組,回傳 `[]` 而非拋出例外。重用共用的 `visual_match` haystack 載入器;不匯入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 加權候選評分
 
 以信心分數排序模稜兩可的元素候選。完整參考:[`docs/source/Zh/doc/new_features/v156_features_doc.rst`](../docs/source/Zh/doc/new_features/v156_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 加權候選評分
+
+以信心分數排序模稜兩可的元素候選。完整參考:[`docs/source/Zh/doc/new_features/v156_features_doc.rst`](../docs/source/Zh/doc/new_features/v156_features_doc.rst)。
+
+- **`score_candidates` / `best_candidate`**(`AC_score_candidates`、`AC_best_candidate`):`anchor_locator` 是單一關係 + 距離排序、`ab_locator` 依耗時競賽整個策略——兩者都不以*加權*混合(角色匹配 + 模糊名稱相似度 + 錨點鄰近 + 啟用狀態)排序模稜候選。本功能回傳最佳優先的 `ScoredCandidate` 並含 `matched_on` 明細;名稱相似度可注入(預設 `fuzzy_ratio`,重用——不新增字串距離程式)。純標準函式庫,作用於元素字典;在多個框都可能是目標時驅動自我修復 / grounding。可無頭測試。
+
 ## 本次更新 (2026-06-23) — 幾何感知的元素差異與穩定 ID
 
 以重疊跨影格追蹤元素,並給予穩定 ID。完整參考:[`docs/source/Zh/doc/new_features/v155_features_doc.rst`](../docs/source/Zh/doc/new_features/v155_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 軟性斷言(彙整所有失敗)
+
+驗證很多項,一次回報每一個失敗。完整參考:[`docs/source/Zh/doc/new_features/v148_features_doc.rst`](../docs/source/Zh/doc/new_features/v148_features_doc.rst)。
+
+- **`SoftAssertions`**(`AC_soft_assert`):`assert_all` 接受事先建好的規格清單——沒有可隨處呼叫 `check()`、並在區塊退出時一次拋出全部的作用域累加器(JUnit5 `assertAll` / Playwright `expect.soft`)。`with SoftAssertions() as soft: soft.check(...)` 記錄通過/失敗(區塊中永不拋出、回傳布林值可分支),退出時一次拋出列出每個失敗——且永不遮蔽已在傳播的例外。執行器命令彙整 JSON `checks` 清單(eq/ne/gt/lt/contains/truthy)。純標準函式庫、可無頭測試。
+
 ## 本次更新 (2026-06-23) — 視窗 Z-order(置頂 / 最前 / 最後)
 
 把視窗釘在最上層、移到最前、或推到後面。完整參考:[`docs/source/Zh/doc/new_features/v147_features_doc.rst`](../docs/source/Zh/doc/new_features/v147_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 剪貼簿檔案拖放清單(CF_HDROP)
+
+把一份檔案清單放上剪貼簿,可直接貼進 Explorer。完整參考:[`docs/source/Zh/doc/new_features/v160_features_doc.rst`](../docs/source/Zh/doc/new_features/v160_features_doc.rst)。
+
+- **`build_dropfiles` / `parse_dropfiles` / `set_clipboard_files` / `get_clipboard_files`**(`AC_set_clipboard_files`、`AC_get_clipboard_files`):剪貼簿原本能承載文字、影像與(透過 `rich_clipboard`)HTML,卻從未支援*檔案清單*——也就是 Explorer 讀取以進行真正檔案複製的 `CF_HDROP` 內容。建構它相當瑣碎(20 位元組 `DROPFILES` 標頭 + 雙重 null 結尾的 UTF-16 路徑清單 + `pFiles` 位移)。本功能把封裝獨立為純粹、可完整測試的 `build_dropfiles` / `parse_dropfiles` 位元組函式,其上再疊加僅限 Windows 的 `set`/`get_clipboard_files` 薄包裝——與 `rich_clipboard` 處理 `CF_HTML` 的拆分方式相同。不匯入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 粗粒度標籤螢幕網格(VLM Grounding)
 
 以網格儲存格(「點擊 C3」)而非原始像素引用螢幕區域。完整參考:[`docs/source/Zh/doc/new_features/v159_features_doc.rst`](../docs/source/Zh/doc/new_features/v159_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 局部動態 / 活動偵測
+
+找出兩幀之間哪些子區域在動。完整參考:[`docs/source/Zh/doc/new_features/v146_features_doc.rst`](../docs/source/Zh/doc/new_features/v146_features_doc.rst)。
+
+- **`changed_regions` / `has_motion` / `activity_score`**(`AC_changed_regions`、`AC_has_motion`):`wait_until_screen_stable` 是布林輪詢、`ssim_changed_regions` 是結構性(忽略快速動態)、`diff_screenshots` 非活動區塊。本功能是便宜的 absdiff 路徑——對逐像素差做門檻、膨脹,回傳移動區域方框(由大到小)、布林值,以及移動像素比例。挑選安靜區域或定位轉圈動畫。兩個可注入幀 → 無頭可測;沿用共用連通元件輔助;執行器中 `after` 預設為即時螢幕擷取。
+
 ## 本次更新 (2026-06-23) — 色彩直方圖指紋與變化偵測
 
 判斷畫面在光照 / 縮放下是否仍是「同一個」。完整參考:[`docs/source/Zh/doc/new_features/v145_features_doc.rst`](../docs/source/Zh/doc/new_features/v145_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 標準化 Computer-Use 動作結構
+
+把 Anthropic / OpenAI agent 動作橋接到 AutoControl 命令。完整參考:[`docs/source/Zh/doc/new_features/v151_features_doc.rst`](../docs/source/Zh/doc/new_features/v151_features_doc.rst)。
+
+- **`from_anthropic` / `from_openai_cua` / `to_ac_command` / `canonical_action`**(`AC_cua_command`):`tool_use_schema` 匯出 AC_* 簽章、`coordinate_space` 縮放——兩者都不*正規化進來的動作酬載*。Anthropic 發出 `{action:"left_click", coordinate:[x,y]}`、OpenAI CUA 發出 `{type:"click", x, y, button}`;這些轉接器把兩者對應為標準動作再對應為可執行的 `[AC_*, params]`(含選用座標空間 `scale`)。純標準函式庫、可無頭測試;執行器命令對任一來源回傳 `{canonical, command}`。
+
 ## 本次更新 (2026-06-23) — 視窗客戶區幾何
 
 不論標題列 / 邊框,點擊視窗*內部*。完整參考:[`docs/source/Zh/doc/new_features/v150_features_doc.rst`](../docs/source/Zh/doc/new_features/v150_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 幾何感知的元素差異與穩定 ID
+
+以重疊跨影格追蹤元素,並給予穩定 ID。完整參考:[`docs/source/Zh/doc/new_features/v155_features_doc.rst`](../docs/source/Zh/doc/new_features/v155_features_doc.rst)。
+
+- **`match_elements` / `assign_stable_ids`**(`AC_match_elements`、`AC_assign_stable_ids`):`diff_snapshots` 以 `(role, name)` 作識別——無法比對改名但未移動或移動了的控制項,也無法跨影格給持久 ID。本功能以 IoU 比對元素框(沿用 `element_parse.iou`):`match_elements` 回傳 `{matched, added, removed}`;`assign_stable_ids` 從 `prior` 影格延續每個元素的 `id`(移動的按鈕保留 id、新增者取得新 id)——讓 agent 能跨回合可靠地引用「element 7」。純標準函式庫、可無頭測試。
+
 ## 本次更新 (2026-06-23) — 可攜式 Agent 軌跡記錄(錄製與重播)
 
 記錄 agent 的觀測→動作步驟並重播。完整參考:[`docs/source/Zh/doc/new_features/v154_features_doc.rst`](../docs/source/Zh/doc/new_features/v154_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 感知式(YIQ)影像比對含反鋸齒抑制
+
+會忽略反鋸齒邊緣的視覺回歸比對。完整參考:[`docs/source/Zh/doc/new_features/v149_features_doc.rst`](../docs/source/Zh/doc/new_features/v149_features_doc.rst)。
+
+- **`perceptual_diff` / `assert_perceptual`**(`AC_perceptual_diff`):`image_difference` 計算原始逐通道差、`ssim_compare` 是整體分數——兩者都未使用感知式度量也不忽略反鋸齒(視覺比對誤報的首要來源)。本功能在 YIQ 空間比較(pixelmatch 的色彩度量),並預設以形態學開運算移除單像素反鋸齒細邊差異,只計算實心變化(`include_aa=True` 保留)。回傳 `{diff_pixels, diff_ratio, regions}`;`assert_perceptual` / `max_diff_ratio` 把關回歸測試。可注入影像配對 → 無頭可測(1px 細邊 → 0、實心區塊 → 計入)。
+
 ## 本次更新 (2026-06-23) — 軟性斷言(彙整所有失敗)
 
 驗證很多項,一次回報每一個失敗。完整參考:[`docs/source/Zh/doc/new_features/v148_features_doc.rst`](../docs/source/Zh/doc/new_features/v148_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 視窗客戶區幾何
+
+不論標題列 / 邊框,點擊視窗*內部*。完整參考:[`docs/source/Zh/doc/new_features/v150_features_doc.rst`](../docs/source/Zh/doc/new_features/v150_features_doc.rst)。
+
+- **`get_client_rect` / `client_point` / `frame_insets` / `client_to_screen`**(`AC_get_client_rect`、`AC_client_point`):`get_window_geometry` 只回傳*外框*——沒有客戶區矩形、框邊內縮運算或客戶區→螢幕對應。`client_point("App", x, y)` 把內容相對點對應到螢幕,讓點擊不論外框都落在視窗內;`frame_insets` 回報邊框 / 標題列厚度。`frame_insets`/`client_to_screen` 是純幾何(可無頭測試);`get_client_rect` 使用可注入的 Win32 讀取器(`GetClientRect`+`ClientToScreen`)。
+
 ## 本次更新 (2026-06-23) — 感知式(YIQ)影像比對含反鋸齒抑制
 
 會忽略反鋸齒邊緣的視覺回歸比對。完整參考:[`docs/source/Zh/doc/new_features/v149_features_doc.rst`](../docs/source/Zh/doc/new_features/v149_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 符記預算內的無障礙文字觀測
+
+把無障礙樹轉成 VLM 可操作的已編號文字區塊。完整參考:[`docs/source/Zh/doc/new_features/v152_features_doc.rst`](../docs/source/Zh/doc/new_features/v152_features_doc.rst)。
+
+- **`serialize_observation` / `observation_index` / `flatten_tree`**(`AC_serialize_observation`、`AC_observation_index`):`describe_screen` 給角色*數量* + 平面標籤清單——沒有穩定索引、沒有 `[12] button "Submit" @(x,y)` 行、沒有視口裁切、沒有符記預算。本功能把(巢狀)元素樹扁平化為僅互動項、裁切到視口、依閱讀順序排序、上限 `max_elements`、指派穩定 `index`,並渲染模型可操作的行(「click [12]」)。純標準函式庫,作用於元素字典;與 `fuse_elements`/`set_of_marks` 搭配。可無頭測試。
+
 ## 本次更新 (2026-06-23) — 標準化 Computer-Use 動作結構
 
 把 Anthropic / OpenAI agent 動作橋接到 AutoControl 命令。完整參考:[`docs/source/Zh/doc/new_features/v151_features_doc.rst`](../docs/source/Zh/doc/new_features/v151_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 視窗 Z-order(置頂 / 最前 / 最後)
+
+把視窗釘在最上層、移到最前、或推到後面。完整參考:[`docs/source/Zh/doc/new_features/v147_features_doc.rst`](../docs/source/Zh/doc/new_features/v147_features_doc.rst)。
+
+- **`set_topmost` / `bring_to_front` / `send_to_back` / `plan_zorder`**(`AC_set_topmost`、`AC_bring_to_front`、`AC_send_to_back`):原始 `set_window_position` 存在但未在 facade、無標題包裝也無 topmost 語意——缺少標準 RPA 的「置頂」。`plan_zorder` 是純動作→`SetWindowPos` 常數查找(可無頭測試);以標題操作的設定器透過可注入 driver(`snap_window` 接縫模式)套用,預設為 Win32。
+
 ## 本次更新 (2026-06-23) — 局部動態 / 活動偵測
 
 找出兩幀之間哪些子區域在動。完整參考:[`docs/source/Zh/doc/new_features/v146_features_doc.rst`](../docs/source/Zh/doc/new_features/v146_features_doc.rst)。

--- a/README/WHATS_NEW_zh-TW.md
+++ b/README/WHATS_NEW_zh-TW.md
@@ -1,5 +1,11 @@
 # 本次更新 — AutoControl
 
+## 本次更新 (2026-06-23) — 旋轉與縮放容忍的樣板比對
+
+不只縮放,還能找到旋轉或傾斜的樣板。完整參考:[`docs/source/Zh/doc/new_features/v158_features_doc.rst`](../docs/source/Zh/doc/new_features/v158_features_doc.rst)。
+
+- **`match_rotated` / `match_rotated_all` / `scale_space`**(`AC_match_rotated`、`AC_match_rotated_all`):`match_template` 只掃描*縮放*且假設軸對齊——OpenCV 的 `matchTemplate` 不具旋轉不變性,因此傾斜的控制項、旋轉的圖示,或轉到不同角度的刻度盤都會比對失敗。本功能掃描 `angles`(每個以 `cv2.warpAffine` 變形)並與 `np.linspace` 縮放空間交叉,回傳相關性最高、且帶有還原 `scale` + `angle` 的 `RotatedMatch`(`*_all` 版本以 NMS 合併相鄰角度 / 縮放)。重用 `visual_match` 的載入器 / resize / 方法表 / NMS——不重複任何比對或幾何程式。`haystack` 可注入;可無頭測試;不匯入 `PySide6`。
+
 ## 本次更新 (2026-06-23) — 一維條碼解碼
 
 從螢幕或影像讀取 EAN / UPC / Code-128 條碼。完整參考:[`docs/source/Zh/doc/new_features/v157_features_doc.rst`](../docs/source/Zh/doc/new_features/v157_features_doc.rst)。

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Window Z-Order (Always-On-Top / Front / Back)
+
+Pin a window on top, raise it, or push it behind. Full reference: [`docs/source/Eng/doc/new_features/v147_features_doc.rst`](docs/source/Eng/doc/new_features/v147_features_doc.rst).
+
+- **`set_topmost` / `bring_to_front` / `send_to_back` / `plan_zorder`** (`AC_set_topmost`, `AC_bring_to_front`, `AC_send_to_back`): the raw `set_window_position` existed but wasn't in the facade, had no title wrapper and no topmost semantics — the standard RPA "always-on-top" was missing. `plan_zorder` is a pure action→`SetWindowPos` constant lookup (headless-testable); the title-based setters apply it through an injectable driver (the `snap_window` seam pattern), Win32 by default. 
+
 ## What's new (2026-06-23) — Localized Motion / Activity Detection
 
 Find which sub-regions are animating between two frames. Full reference: [`docs/source/Eng/doc/new_features/v146_features_doc.rst`](docs/source/Eng/doc/new_features/v146_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Clipboard File-Drop List (CF_HDROP)
+
+Put a list of files on the clipboard, ready to paste into Explorer. Full reference: [`docs/source/Eng/doc/new_features/v160_features_doc.rst`](docs/source/Eng/doc/new_features/v160_features_doc.rst).
+
+- **`build_dropfiles` / `parse_dropfiles` / `set_clipboard_files` / `get_clipboard_files`** (`AC_set_clipboard_files`, `AC_get_clipboard_files`): the clipboard carried text, images and (via `rich_clipboard`) HTML, but never a *file list* — the `CF_HDROP` payload Explorer reads to paste files as a real copy. Building it is fiddly (20-byte `DROPFILES` header + double-null-terminated UTF-16 path list + `pFiles` offset). This isolates the packing into pure, fully testable `build_dropfiles` / `parse_dropfiles` byte functions, with thin Windows-only `set`/`get_clipboard_files` wrappers on top — the same split `rich_clipboard` uses for `CF_HTML`. No `PySide6`.
+
 ## What's new (2026-06-23) — Coarse Labelled Screen Grid (VLM Grounding)
 
 Refer to screen regions as grid cells ("click C3") instead of raw pixels. Full reference: [`docs/source/Eng/doc/new_features/v159_features_doc.rst`](docs/source/Eng/doc/new_features/v159_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Localized Motion / Activity Detection
+
+Find which sub-regions are animating between two frames. Full reference: [`docs/source/Eng/doc/new_features/v146_features_doc.rst`](docs/source/Eng/doc/new_features/v146_features_doc.rst).
+
+- **`changed_regions` / `has_motion` / `activity_score`** (`AC_changed_regions`, `AC_has_motion`): `wait_until_screen_stable` is a boolean poll, `ssim_changed_regions` is structural (ignores fast motion), `diff_screenshots` isn't activity blobs. This is the cheap absdiff path — threshold the per-pixel difference, dilate, and return the moved-region boxes (largest first), a boolean, and the fraction of pixels that moved. Pick a quiet area or locate a spinner. Two injectable frames → headless-testable; reuses the shared connected-components helper; `after` defaults to a live screen grab in the executor.
+
 ## What's new (2026-06-23) — Colour-Histogram Fingerprint & Change Detection
 
 Tell whether the view is "the same" despite lighting / scale. Full reference: [`docs/source/Eng/doc/new_features/v145_features_doc.rst`](docs/source/Eng/doc/new_features/v145_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Weighted Candidate Scoring
+
+Rank ambiguous element candidates by a confidence score. Full reference: [`docs/source/Eng/doc/new_features/v156_features_doc.rst`](docs/source/Eng/doc/new_features/v156_features_doc.rst).
+
+- **`score_candidates` / `best_candidate`** (`AC_score_candidates`, `AC_best_candidate`): `anchor_locator` is a single relation + distance sort and `ab_locator` races whole strategies by elapsed time — neither ranks ambiguous candidates by a *weighted* mix of role match + fuzzy name similarity + anchor proximity + enabled-state. This returns `ScoredCandidate`s best-first with a `matched_on` breakdown; the name similarity is injectable (default `fuzzy_ratio`, reused — no new string-distance code). Pure-stdlib over element dicts; powers self-heal / grounding when several boxes could be the target. Headless-testable.
+
 ## What's new (2026-06-23) — Geometry-Aware Element Diff & Stable IDs
 
 Track elements across frames by overlap, with stable IDs. Full reference: [`docs/source/Eng/doc/new_features/v155_features_doc.rst`](docs/source/Eng/doc/new_features/v155_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Canonical Computer-Use Action Schema
+
+Bridge Anthropic / OpenAI agent actions to AutoControl commands. Full reference: [`docs/source/Eng/doc/new_features/v151_features_doc.rst`](docs/source/Eng/doc/new_features/v151_features_doc.rst).
+
+- **`from_anthropic` / `from_openai_cua` / `to_ac_command` / `canonical_action`** (`AC_cua_command`): `tool_use_schema` exports AC_* signatures and `coordinate_space` rescales — neither *normalizes an inbound action payload*. Anthropic emits `{action:"left_click", coordinate:[x,y]}`, OpenAI CUA emits `{type:"click", x, y, button}`; these adapters map both to a canonical action and then to a runnable `[AC_*, params]` (with optional coordinate-space `scale`). Pure-stdlib, headless-testable; the executor command returns `{canonical, command}` for any source.
+
 ## What's new (2026-06-23) — Window Client-Area Geometry
 
 Click *inside* a window regardless of its title bar / borders. Full reference: [`docs/source/Eng/doc/new_features/v150_features_doc.rst`](docs/source/Eng/doc/new_features/v150_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Pre-Action Grounding Guard
+
+Reject out-of-bounds clicks; snap near-misses onto the real element. Full reference: [`docs/source/Eng/doc/new_features/v153_features_doc.rst`](docs/source/Eng/doc/new_features/v153_features_doc.rst).
+
+- **`validate_action` / `snap_to_element` / `in_bounds`** (`AC_validate_action`): `guardrail` scans text and `loop_guard` detects loops — neither validates a coordinate action before dispatch, so a hallucinated `(9999,-5)` click fires into nothing and a 5px-off click misses. This rejects off-screen coordinates and, given `targets`, snaps a near-miss onto the nearest element's centre, returning `{ok, reason, snapped}`. Pure-stdlib geometry over element dicts; the executor `screen` defaults to the live screen. Headless-testable; plugs in front of an agent loop's dispatch.
+
 ## What's new (2026-06-23) — Token-Budgeted A11y Text Observation
 
 Turn the a11y tree into an indexed text block a VLM can act on. Full reference: [`docs/source/Eng/doc/new_features/v152_features_doc.rst`](docs/source/Eng/doc/new_features/v152_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Portable Agent-Trajectory Trace (Record & Replay)
+
+Log an agent's observation→action steps and replay them. Full reference: [`docs/source/Eng/doc/new_features/v154_features_doc.rst`](docs/source/Eng/doc/new_features/v154_features_doc.rst).
+
+- **`record_step` / `to_jsonl` / `from_jsonl` / `replay_trace`** (`AC_replay_trace`): `agent_trace` records OTel spans (observability), `trajectory_eval` only scores, `semantic_recording` replays human macros — none is a replayable obs→action transcript. This is the OmniTool-style `{step, observation, action, result}` JSONL with a deterministic replay driver (injectable `runner`, no live model). The executor command replays each step's AC action through the executor. Pure-stdlib, headless-testable; build regression / training datasets from agent runs.
+
 ## What's new (2026-06-23) — Pre-Action Grounding Guard
 
 Reject out-of-bounds clicks; snap near-misses onto the real element. Full reference: [`docs/source/Eng/doc/new_features/v153_features_doc.rst`](docs/source/Eng/doc/new_features/v153_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Colour-Histogram Fingerprint & Change Detection
+
+Tell whether the view is "the same" despite lighting / scale. Full reference: [`docs/source/Eng/doc/new_features/v145_features_doc.rst`](docs/source/Eng/doc/new_features/v145_features_doc.rst).
+
+- **`image_histogram` / `compare_histograms` / `histogram_changed`** (`AC_image_histogram`, `AC_histogram_changed`): `image_dedup`'s perceptual hash is spatial (brittle to colour/theme) and `color_stats` is one colour. A normalized colour histogram is the illumination/scale-robust "same view, or palette shifted?" signal (theme switch, reload, rotated banner). `image_histogram` returns a per-channel histogram (`hsv`/`rgb`/`gray`); `compare_histograms` does correlation/chisqr/intersection/bhattacharyya; `histogram_changed` compares a reference vs the live screen. Injectable image → headless-testable; base OpenCV (`cv2.calcHist`/`compareHist`).
+
 ## What's new (2026-06-23) — Rich Clipboard (HTML / CF_HTML)
 
 Copy and paste *formatted* HTML into Word / Outlook. Full reference: [`docs/source/Eng/doc/new_features/v144_features_doc.rst`](docs/source/Eng/doc/new_features/v144_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Rotation- & Scale-Tolerant Template Matching
+
+Find templates that are rotated or skewed, not just scaled. Full reference: [`docs/source/Eng/doc/new_features/v158_features_doc.rst`](docs/source/Eng/doc/new_features/v158_features_doc.rst).
+
+- **`match_rotated` / `match_rotated_all` / `scale_space`** (`AC_match_rotated`, `AC_match_rotated_all`): `match_template` sweeps *scales* but assumes axis-aligned — OpenCV's `matchTemplate` isn't rotation-invariant, so a skewed control, a rotated icon or a dial at a different angle is missed. This sweeps `angles` (each warped with `cv2.warpAffine`) crossed with a `np.linspace` scale-space, returns the best-correlating `RotatedMatch` carrying the recovered `scale` + `angle` (the `*_all` form NMS-dedupes neighbouring angles/scales). Reuses `visual_match`'s loaders / resize / method table / NMS — no matching or geometry code duplicated. Injectable `haystack`; headless-testable; no `PySide6`.
+
 ## What's new (2026-06-23) — Barcode Decoding (1-D)
 
 Read EAN / UPC / Code-128 barcodes off the screen or an image. Full reference: [`docs/source/Eng/doc/new_features/v157_features_doc.rst`](docs/source/Eng/doc/new_features/v157_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Geometry-Aware Element Diff & Stable IDs
+
+Track elements across frames by overlap, with stable IDs. Full reference: [`docs/source/Eng/doc/new_features/v155_features_doc.rst`](docs/source/Eng/doc/new_features/v155_features_doc.rst).
+
+- **`match_elements` / `assign_stable_ids`** (`AC_match_elements`, `AC_assign_stable_ids`): `diff_snapshots` keys identity on `(role, name)` — it can't match a renamed-but-stationary control or a moved one, nor give persistent IDs across frames. This matches element boxes by IoU (reusing `element_parse.iou`): `match_elements` returns `{matched, added, removed}`; `assign_stable_ids` carries each element's `id` from a `prior` frame (a moved button keeps its id, a new one gets a fresh id) — so an agent can reliably refer to "element 7" turn-over-turn. Pure-stdlib, headless-testable.
+
 ## What's new (2026-06-23) — Portable Agent-Trajectory Trace (Record & Replay)
 
 Log an agent's observation→action steps and replay them. Full reference: [`docs/source/Eng/doc/new_features/v154_features_doc.rst`](docs/source/Eng/doc/new_features/v154_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Token-Budgeted A11y Text Observation
+
+Turn the a11y tree into an indexed text block a VLM can act on. Full reference: [`docs/source/Eng/doc/new_features/v152_features_doc.rst`](docs/source/Eng/doc/new_features/v152_features_doc.rst).
+
+- **`serialize_observation` / `observation_index` / `flatten_tree`** (`AC_serialize_observation`, `AC_observation_index`): `describe_screen` gives role *counts* + a flat label list — no stable index, no `[12] button "Submit" @(x,y)` lines, no viewport clip, no token budget. This flattens a (nested) element tree to interactive-only, clips to the viewport, orders reading-style, caps at `max_elements`, assigns a stable `index`, and renders the lines a model acts on ("click [12]"). Pure-stdlib over element dicts; pairs with `fuse_elements`/`set_of_marks`. Headless-testable.
+
 ## What's new (2026-06-23) — Canonical Computer-Use Action Schema
 
 Bridge Anthropic / OpenAI agent actions to AutoControl commands. Full reference: [`docs/source/Eng/doc/new_features/v151_features_doc.rst`](docs/source/Eng/doc/new_features/v151_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Soft Assertions (Aggregate Failures)
+
+Verify many things, report every failure at once. Full reference: [`docs/source/Eng/doc/new_features/v148_features_doc.rst`](docs/source/Eng/doc/new_features/v148_features_doc.rst).
+
+- **`SoftAssertions`** (`AC_soft_assert`): `assert_all` takes a pre-built spec list up front — there was no scoped accumulator you sprinkle `check()` calls into that raises everything on block exit (JUnit5 `assertAll` / Playwright `expect.soft`). `with SoftAssertions() as soft: soft.check(...)` records pass/fail (never raising mid-block, returns the bool to branch on), then raises once on exit listing every failure — and never masks an exception already propagating. The executor command aggregates a JSON `checks` list (eq/ne/gt/lt/contains/truthy). Pure-stdlib, headless-testable.
+
 ## What's new (2026-06-23) — Window Z-Order (Always-On-Top / Front / Back)
 
 Pin a window on top, raise it, or push it behind. Full reference: [`docs/source/Eng/doc/new_features/v147_features_doc.rst`](docs/source/Eng/doc/new_features/v147_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Perceptual (YIQ) Image Diff with Anti-Alias Suppression
+
+Visual-regression diffing that ignores anti-aliased edges. Full reference: [`docs/source/Eng/doc/new_features/v149_features_doc.rst`](docs/source/Eng/doc/new_features/v149_features_doc.rst).
+
+- **`perceptual_diff` / `assert_perceptual`** (`AC_perceptual_diff`): `image_difference` counts raw per-channel deltas and `ssim_compare` is a global score — neither uses a perceptual metric or ignores anti-aliasing, the #1 source of false-positive visual-diff failures. This compares in YIQ space (pixelmatch's colour metric) and, by default, removes thin 1px anti-aliased edge diffs via a morphological open so only solid changes count (`include_aa=True` keeps them). Returns `{diff_pixels, diff_ratio, regions}`; `assert_perceptual` / `max_diff_ratio` gate a regression test. Injectable image pair → headless-testable (a 1px fringe → 0, a solid block → counted).
+
 ## What's new (2026-06-23) — Soft Assertions (Aggregate Failures)
 
 Verify many things, report every failure at once. Full reference: [`docs/source/Eng/doc/new_features/v148_features_doc.rst`](docs/source/Eng/doc/new_features/v148_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Coarse Labelled Screen Grid (VLM Grounding)
+
+Refer to screen regions as grid cells ("click C3") instead of raw pixels. Full reference: [`docs/source/Eng/doc/new_features/v159_features_doc.rst`](docs/source/Eng/doc/new_features/v159_features_doc.rst).
+
+- **`grid_cells` / `cell_for_point` / `point_for_cell`** (`AC_grid_cells`, `AC_cell_for_point`, `AC_point_for_cell`): VLM grounding is far more reliable when a model names a coarse cell than when it emits hallucinated pixel coordinates. This lays an `rows`x`cols` grid over the screen (or a `region`), labels each cell spreadsheet-style (`A1` top-left, past `Z` → `AA`), and maps both ways — point → containing cell, named cell → centre point (ready to click). Pure-stdlib geometry; the only device-bound path is the default that reads the live screen size, so every function is headless-testable with an explicit `region`. No `PySide6`.
+
 ## What's new (2026-06-23) — Rotation- & Scale-Tolerant Template Matching
 
 Find templates that are rotated or skewed, not just scaled. Full reference: [`docs/source/Eng/doc/new_features/v158_features_doc.rst`](docs/source/Eng/doc/new_features/v158_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Barcode Decoding (1-D)
+
+Read EAN / UPC / Code-128 barcodes off the screen or an image. Full reference: [`docs/source/Eng/doc/new_features/v157_features_doc.rst`](docs/source/Eng/doc/new_features/v157_features_doc.rst).
+
+- **`read_barcodes`** (`AC_read_barcodes`): the framework decoded QR codes (`read_qr`) but had no reader for the *1-D* barcodes (EAN-13/8, UPC-A, Code-128) that label physical goods, inventory tickets and shipping labels. This decodes them via OpenCV's `cv2.barcode.BarcodeDetector`, returning `{text, type, points}` per code. The decode step is an injectable seam (default calls OpenCV; tests pass their own `decoder`), so it's fully headless-testable and degrades gracefully — an OpenCV build without the `barcode` module returns `[]` instead of raising. Reuses the shared `visual_match` haystack loader; no `PySide6`.
+
 ## What's new (2026-06-23) — Weighted Candidate Scoring
 
 Rank ambiguous element candidates by a confidence score. Full reference: [`docs/source/Eng/doc/new_features/v156_features_doc.rst`](docs/source/Eng/doc/new_features/v156_features_doc.rst).

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
 # What's New — AutoControl
 
+## What's new (2026-06-23) — Window Client-Area Geometry
+
+Click *inside* a window regardless of its title bar / borders. Full reference: [`docs/source/Eng/doc/new_features/v150_features_doc.rst`](docs/source/Eng/doc/new_features/v150_features_doc.rst).
+
+- **`get_client_rect` / `client_point` / `frame_insets` / `client_to_screen`** (`AC_get_client_rect`, `AC_client_point`): `get_window_geometry` returns only the *outer* bbox — there was no client-area rect, frame-inset math, or client→screen mapping. `client_point("App", x, y)` maps a content-relative point to the screen so a click lands inside the window regardless of chrome; `frame_insets` reports border/title-bar thickness. `frame_insets`/`client_to_screen` are pure geometry (headless-testable); `get_client_rect` uses an injectable Win32 reader (`GetClientRect`+`ClientToScreen`).
+
 ## What's new (2026-06-23) — Perceptual (YIQ) Image Diff with Anti-Alias Suppression
 
 Visual-regression diffing that ignores anti-aliased edges. Full reference: [`docs/source/Eng/doc/new_features/v149_features_doc.rst`](docs/source/Eng/doc/new_features/v149_features_doc.rst).

--- a/docs/source/Eng/doc/new_features/v145_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v145_features_doc.rst
@@ -1,0 +1,44 @@
+Colour-Histogram Fingerprint & Change Detection
+===============================================
+
+``image_dedup`` fingerprints with a perceptual aHash / dHash — a *spatial* 64-bit
+hash that is brittle to colour and theme shifts — and ``color_stats`` reports a single
+average / dominant colour. A normalized colour *histogram* is the standard
+illumination- and scale-robust signal for "is this the same view, or has the palette
+shifted?": a theme switch, a content reload, a rotated banner — which neither hashing
+nor one dominant colour captures.
+
+Every function runs on an injectable image (ndarray / path / PIL, RGB), so it is
+headless-testable on synthetic arrays. ``cv2.calcHist`` / ``cv2.compareHist`` are base
+OpenCV; OpenCV + NumPy come in via ``je_open_cv``. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import (image_histogram, compare_histograms,
+                                 histogram_changed)
+
+    baseline = image_histogram("golden.png")          # 3 * bins floats (HSV)
+    if histogram_changed("golden.png"):               # current = live screen
+        print("the view changed")
+
+    score = compare_histograms(baseline, image_histogram())   # 1.0 == identical
+
+``image_histogram`` returns a per-channel normalized histogram as a flat list
+(``space`` = ``hsv`` / ``rgb`` / ``gray``; each channel adds ``bins`` values).
+``compare_histograms`` supports ``correlation`` / ``chisqr`` / ``intersection`` /
+``bhattacharyya`` (for correlation / intersection higher is more similar; for the
+distance methods higher is more different). ``histogram_changed`` compares a
+``reference`` against ``current`` (default: the screen) and returns a bool, flipping
+the threshold comparison automatically for similarity vs distance methods.
+
+Executor commands
+-----------------
+
+``AC_image_histogram`` (``source`` / ``bins`` / ``space`` / ``region`` →
+``{bins, space, histogram}``) and ``AC_histogram_changed`` (``reference`` /
+``current`` / ``method`` / ``threshold`` / ``space`` / ``region`` →
+``{changed, score}``). They are exposed as the MCP tools ``ac_image_histogram`` /
+``ac_histogram_changed`` and as Script Builder commands under **Image**.

--- a/docs/source/Eng/doc/new_features/v146_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v146_features_doc.rst
@@ -1,0 +1,45 @@
+Localized Motion / Activity Detection
+=====================================
+
+Three near-neighbours, all distinct: ``wait_until_screen_stable`` returns a *boolean*
+over a live poll loop (not localized boxes on an injectable pair); ``ssim_changed_regions``
+is *structural* (Gaussian-windowed SSIM, illumination-tolerant — it deliberately ignores
+the fast pixel motion you want for "where is the spinner / video / animation");
+``diff_screenshots`` highlights pixel diffs but is not framed as activity blobs with a
+score. ``changed_regions`` / ``has_motion`` / ``activity_score`` are the cheap absdiff
+path: which sub-regions are *moving* between two frames, so a script can pick a quiet
+area or locate a busy spinner.
+
+They operate on two injectable frames (ndarray / path / PIL), so they are headless-
+testable on synthetic arrays, and reuse the shared connected-component helper. OpenCV +
+NumPy come in via ``je_open_cv``. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import changed_regions, has_motion, activity_score
+
+    before = screenshot_to_array()
+    # ... time passes ...
+    for box in changed_regions(before, after):     # boxes that moved, largest first
+        print(box["x"], box["y"], box["width"], box["height"])
+
+    if has_motion(before, after):
+        print("still animating, activity =", activity_score(before, after))
+
+``changed_regions`` thresholds the absolute difference (``threshold``), denoises
+(``blur``), dilates and returns ``{x, y, width, height, area, center}`` blobs of at
+least ``min_area``, largest first. ``has_motion`` is the boolean form; ``activity_score``
+is the fraction (0..1) of pixels that moved. Frames of different sizes raise
+``ValueError``.
+
+Executor commands
+-----------------
+
+``AC_changed_regions`` (``before`` / ``after`` / ``threshold`` / ``min_area`` /
+``blur`` → ``{count, regions}``) and ``AC_has_motion`` (``before`` / ``after`` /
+``threshold`` / ``min_area`` → ``{moved, activity}``); ``after`` defaults to a live
+screen grab. They are exposed as the MCP tools ``ac_changed_regions`` /
+``ac_has_motion`` and as Script Builder commands under **Image**.

--- a/docs/source/Eng/doc/new_features/v147_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v147_features_doc.rst
@@ -1,0 +1,42 @@
+Window Z-Order — Always-On-Top / Front / Back
+=============================================
+
+``windows_window_manage.set_window_position`` exists at the raw Win32 layer but is not
+exported in the package facade, has no title-based wrapper, and no topmost / not-topmost
+semantics — and there was no ``always_on_top`` anywhere outside GUI overlay code. This
+adds the standard RPA z-order primitive: a pure ``plan_zorder`` that maps an action to
+the ``SetWindowPos`` insert-after constant, plus title-based ``set_topmost`` /
+``bring_to_front`` / ``send_to_back`` over an injectable driver (the same seam pattern
+as ``snap_window``).
+
+The planning is pure and headless-testable; only the default driver touches Win32
+(returning ``False`` on other platforms). Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import (set_topmost, bring_to_front, send_to_back,
+                                 plan_zorder)
+
+    set_topmost("Media Player")          # pin always-on-top
+    set_topmost("Media Player", False)   # release
+    bring_to_front("Editor")
+    send_to_back("Background Monitor")
+
+    plan_zorder("topmost")["insert_after"]   # -1 (HWND_TOPMOST), pure / testable
+
+``plan_zorder(action)`` (``top`` / ``bottom`` / ``topmost`` / ``notopmost``) returns the
+``SetWindowPos`` descriptor (``insert_after`` constant + ``SWP_NOMOVE`` / ``SWP_NOSIZE``
+flags); unknown actions raise ``ValueError``. ``set_topmost`` / ``bring_to_front`` /
+``send_to_back`` resolve the window by title and apply the action through the default
+Win32 driver (or an injected one in tests), returning whether it was applied.
+
+Executor commands
+-----------------
+
+``AC_set_topmost`` (``title`` / ``on`` → ``{applied}``), ``AC_bring_to_front`` and
+``AC_send_to_back`` (``title`` → ``{applied}``). They are exposed as the MCP tools
+``ac_set_topmost`` / ``ac_bring_to_front`` / ``ac_send_to_back`` and as Script Builder
+commands under **Window**.

--- a/docs/source/Eng/doc/new_features/v148_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v148_features_doc.rst
@@ -1,0 +1,39 @@
+Soft Assertions — Aggregate Failures at Block End
+=================================================
+
+``assertion.assert_all`` takes a **pre-built list of spec dicts up front**. There is no
+*scoped accumulator* you sprinkle ``check()`` calls into across interleaved actions and
+that raises everything at once on exit — the JUnit5 ``assertAll`` / Playwright
+``expect.soft`` / AssertJ ``SoftAssertions`` pattern, the standard ergonomics for
+verifying many fields of a form without stopping at the first failure.
+
+Pure-stdlib context manager; imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import SoftAssertions
+
+    with SoftAssertions() as soft:
+        soft.check(title == "Invoice", "wrong title")
+        soft.check_equal(total, "$42.00", "wrong total")
+        soft.check(date_field_is_visible(), "date field missing")
+    # on exit, raises once listing EVERY failed check (or nothing if all passed)
+
+``check(condition, message)`` records a pass/fail and never raises (it returns the
+bool, so you can branch on it); ``check_equal(actual, expected, message)`` is the
+equality shortcut. ``failures`` lists the failed messages, ``passed`` counts the
+passes, and ``assert_all()`` raises ``AutoControlActionException`` aggregating them.
+The context manager calls ``assert_all`` on a clean exit (and never masks an exception
+already propagating). Pass ``raise_on_exit=False`` to collect without auto-raising.
+
+Executor command
+----------------
+
+``AC_soft_assert`` evaluates a list of ``checks`` (each ``{value, op, expected,
+message}`` with ``op`` = ``eq`` / ``ne`` / ``gt`` / ``lt`` / ``contains`` /
+``truthy``) and returns ``{ok, passed, failures}`` — reporting *all* failures, not
+just the first; set ``raise_on_fail`` to raise instead. It is exposed as the MCP tool
+``ac_soft_assert`` and as a Script Builder command under **Flow**.

--- a/docs/source/Eng/doc/new_features/v149_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v149_features_doc.rst
@@ -1,0 +1,42 @@
+Perceptual (YIQ) Image Diff with Anti-Alias Suppression
+=======================================================
+
+``visual_regression.image_difference`` counts raw per-channel max-delta pixels and
+``ssim_compare`` gives a global structural score. Neither uses a *perceptual* colour
+metric, and neither ignores **anti-aliased edges** — the #1 source of false-positive
+visual-diff failures across DPI and font-hinting. ``perceptual_diff`` compares pixels
+in YIQ space (the pixelmatch colour metric, far closer to human perception than RGB)
+and, by default, removes the thin one-pixel edge differences that anti-aliasing
+produces (a morphological open), so only *solid* changed regions count.
+
+Runs on an injectable image pair (ndarray / path / PIL), so it is headless-testable on
+synthetic arrays. OpenCV + NumPy come in via ``je_open_cv``; reuses the shared
+connected-component helper and RGB loader. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import perceptual_diff, assert_perceptual
+
+    result = perceptual_diff("actual.png", "golden.png", threshold=0.1)
+    print(result.diff_pixels, result.diff_ratio, result.regions)
+
+    # Gate a visual-regression test (raises if the ratio is exceeded).
+    assert_perceptual("actual.png", "golden.png", max_diff_ratio=0.01)
+
+``perceptual_diff`` returns a ``PerceptualDiffResult`` (``diff_pixels``,
+``total_pixels``, ``diff_ratio``, and the ``regions`` boxes of the changed clusters).
+``threshold`` (0..1) is the pixelmatch sensitivity. ``include_aa=True`` keeps the thin
+edge differences instead of suppressing them. ``assert_perceptual`` raises
+``AutoControlActionException`` when ``diff_ratio`` exceeds ``max_diff_ratio``. Images of
+different sizes raise ``ValueError``.
+
+Executor command
+----------------
+
+``AC_perceptual_diff`` (``actual`` / ``expected`` / ``threshold`` / ``include_aa`` /
+``max_diff_ratio`` → ``{diff_pixels, total_pixels, diff_ratio, regions}``; raises when
+``max_diff_ratio`` is given and exceeded). It is exposed as the MCP tool
+``ac_perceptual_diff`` and as a Script Builder command under **Image**.

--- a/docs/source/Eng/doc/new_features/v150_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v150_features_doc.rst
@@ -1,0 +1,43 @@
+Window Client-Area Geometry
+===========================
+
+``window_capture.get_window_geometry`` returns a window's *outer* bounding box (for
+screenshotting), but there is no *client*-area rect, no frame-inset math, and no
+client→screen point mapping. RPA needs "click at ``(x, y)`` *inside* this window's
+client area regardless of title-bar height / borders" — the building block for
+window-relative clicking. This adds the client rect, the pure frame-inset and
+client-to-screen helpers, and a one-call ``client_point``.
+
+``frame_insets`` / ``client_to_screen`` are pure geometry (headless-testable); only
+``get_client_rect``'s default reader touches Win32 (``GetClientRect`` +
+``ClientToScreen``), and it is injectable. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import (get_client_rect, client_point, frame_insets,
+                                 client_to_screen)
+
+    # Click 20px in, 30px down from the window's content origin (not its title bar).
+    point = client_point("Calculator", 20, 30)
+    if point:
+        click(*point)
+
+    rect = get_client_rect("Calculator")               # (x, y, width, height)
+    insets = frame_insets(get_window_geometry("Calculator"), rect)  # border sizes
+
+``get_client_rect`` returns the client area as ``(x, y, width, height)`` with a
+screen-coordinate origin (or ``None``); ``client_point`` maps a client-local point to
+the screen so a click lands inside the content regardless of chrome. ``frame_insets``
+returns the ``{left, top, right, bottom}`` border/title-bar thickness from the outer
+and client rects, and ``client_to_screen`` is the underlying pure offset.
+
+Executor commands
+-----------------
+
+``AC_get_client_rect`` (``title`` → ``{found, rect}``) and ``AC_client_point``
+(``title`` / ``x`` / ``y`` → ``{found, point}``). They are exposed as the MCP tools
+``ac_get_client_rect`` / ``ac_client_point`` and as Script Builder commands under
+**Window**.

--- a/docs/source/Eng/doc/new_features/v151_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v151_features_doc.rst
@@ -1,0 +1,45 @@
+Canonical Computer-Use Action Schema
+====================================
+
+``tool_use_schema`` exports the AC_* command *signatures* as tool definitions and
+``coordinate_space`` rescales a model grid — but neither *normalizes an inbound action
+payload*. Anthropic's computer-use tool emits ``{action:"left_click",
+coordinate:[x,y]}``, OpenAI's CUA emits ``{type:"click", x, y, button}`` — there was no
+adapter mapping these heterogeneous shapes onto a canonical action and then onto a
+runnable AC_* command, so integrators hand-wrote the glue.
+
+Pure-stdlib dict mapping (an optional ``scale`` callable applies coordinate-space
+rescaling), fully headless-testable. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import (from_anthropic, from_openai_cua, to_ac_command,
+                                 canonical_action)
+
+    # Anthropic agent output -> canonical -> runnable AC action.
+    canonical = from_anthropic({"action": "left_click", "coordinate": [120, 80]})
+    command = to_ac_command(canonical)
+    # -> ["AC_click_mouse", {"mouse_keycode": "mouse_left", "x": 120, "y": 80}]
+
+    # OpenAI CUA, with model->physical coordinate rescaling.
+    cmd = to_ac_command(from_openai_cua({"type": "scroll", "x": 5, "y": 6,
+                                         "scroll_y": 120}),
+                        scale=lambda x, y: (x * 2, y * 2))
+
+``from_anthropic`` / ``from_openai_cua`` map each provider's payload to a canonical
+``{type, x, y, text, …}`` (clicks, double/right/middle click, move, type, key, scroll,
+screenshot). ``to_ac_command`` maps a canonical action to a ``[command_name, params]``
+AC action (``AC_click_mouse`` / ``AC_set_mouse_position`` / ``AC_write`` / ``AC_hotkey``
+/ ``AC_mouse_scroll`` / ``AC_screenshot``), applying ``scale`` to coordinates; an
+unmapped type raises ``AutoControlActionException``. ``canonical_action`` builds a
+canonical dict directly.
+
+Executor command
+----------------
+
+``AC_cua_command`` normalizes a ``payload`` from ``source`` (``anthropic`` / ``openai``
+/ ``canonical``) and returns ``{canonical, command}``. It is exposed as the MCP tool
+``ac_cua_command`` and as a Script Builder command under **Native UI**.

--- a/docs/source/Eng/doc/new_features/v152_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v152_features_doc.rst
@@ -1,0 +1,44 @@
+Token-Budgeted A11y Text Observation
+====================================
+
+``screen_state.describe_screen`` returns role *counts* plus a flat list of control
+labels — but no stable per-element index, no ``[12] button "Submit" @(x,y)`` lines, no
+viewport clipping, and no element cap / token budget. Modern desktop and web agents
+feed a *flattened, indexed, viewport-pruned* text block (the "accessibility tree as the
+text observation" pattern) and then act by index ("click [12]"). This builds that
+observation and the index behind it, pairing with :doc:`v138_features_doc` and
+``set_of_marks``.
+
+Pure-stdlib over plain element dicts (``role`` / ``name`` / ``x`` / ``y`` / ``width`` /
+``height``, optionally nested ``children``), so it is fully unit-testable. Imports no
+``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import (serialize_observation, observation_index,
+                                 flatten_tree)
+
+    text = serialize_observation(a11y_tree, viewport=(0, 0, 1920, 1080),
+                                 max_elements=60)
+    # [0] button "Save" @(30,20)
+    # [1] textbox "Search" @(140,20)
+    # ... feed `text` to the model; it replies "click [1]"
+
+    target = observation_index(a11y_tree)[1]      # the structured element behind [1]
+    click(*[target["x"] + target["width"] // 2, target["y"] + target["height"] // 2])
+
+``flatten_tree`` flattens a nested element tree, keeping only interactive roles by
+default. ``observation_index`` clips to the ``viewport``, orders top-to-bottom /
+left-to-right, caps at ``max_elements`` and assigns a stable ``index``.
+``serialize_observation`` renders those as ``[i] role "name" @(cx,cy)`` lines.
+
+Executor commands
+-----------------
+
+``AC_serialize_observation`` (``elements`` / ``viewport`` / ``max_elements`` →
+``{observation, count}``) and ``AC_observation_index`` (same inputs →
+``{count, elements}``). They are exposed as the MCP tools ``ac_serialize_observation``
+/ ``ac_observation_index`` and as Script Builder commands under **Native UI**.

--- a/docs/source/Eng/doc/new_features/v153_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v153_features_doc.rst
@@ -1,0 +1,40 @@
+Pre-Action Grounding Guard
+==========================
+
+``guardrail`` scans text for prompt-injection and ``loop_guard`` detects stuck loops —
+but neither validates a *coordinate action* before it is dispatched. An agent loop
+executes whatever the model returns with no bounds or target check, so a hallucinated
+``(9999, -5)`` click fires into nothing and a 5-pixel-off click misses the button.
+``validate_action`` adds the "detect misaligned actions before execution" guard: reject
+clicks outside the screen and snap a near-miss coordinate onto the nearest known
+element's centre.
+
+Pure-stdlib geometry over plain element dicts (``x`` / ``y`` / ``width`` / ``height``),
+so it is fully unit-testable. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import validate_action, snap_to_element, in_bounds
+
+    check = validate_action(model_action, screen_size=(1920, 1080), targets=elements)
+    if not check["ok"]:
+        print("rejected:", check["reason"])         # e.g. "out of bounds"
+    else:
+        x, y = check["snapped"] or (model_action["x"], model_action["y"])
+        click(x, y)                                  # snapped onto the real button
+
+``in_bounds(x, y, screen_size)`` is the screen-bounds predicate; ``snap_to_element``
+returns the centre of the element at (or nearest within ``max_dist`` of) a point, or
+``None``; ``validate_action`` combines them, returning ``{ok, reason, snapped}`` —
+rejecting out-of-bounds coordinates and snapping near-misses when ``targets`` are
+supplied. Actions without a coordinate always pass.
+
+Executor command
+----------------
+
+``AC_validate_action`` (``action`` / ``screen`` / ``targets`` → ``{ok, reason,
+snapped}``; ``screen`` defaults to the live screen). It is exposed as the MCP tool
+``ac_validate_action`` and as a Script Builder command under **Native UI**.

--- a/docs/source/Eng/doc/new_features/v154_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v154_features_doc.rst
@@ -1,0 +1,45 @@
+Portable Agent-Trajectory Trace (Record & Replay)
+=================================================
+
+``agent_trace`` records OpenTelemetry GenAI *spans* (tokens / latency / cost) — that is
+observability, not a replayable observation→action transcript; ``trajectory_eval``
+*scores* a trajectory but defines no persisted format and cannot replay it; and
+``semantic_recording`` replays recorded *human input macros*, not *agent* decisions.
+This adds the OmniTool-style "log the trajectory to build a replay / training dataset"
+format: ``{step, observation, action, result}`` JSONL with a deterministic replay
+driver.
+
+Pure-stdlib JSONL; the replay driver takes an injectable ``runner`` (no live model), so
+it is fully unit-testable. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import record_step, to_jsonl, from_jsonl, replay_trace
+
+    trace = []
+    record_step(trace, observation="login screen",
+                action=["AC_click_mouse", {"x": 120, "y": 80}])
+    record_step(trace, observation="typed user", action=["AC_write",
+                {"write_string": "alice"}], result={"ok": True})
+
+    open("run.jsonl", "w").write(to_jsonl(trace))     # persist a dataset
+
+    # Later — replay every step through any runner (here a fake for tests).
+    results = replay_trace(from_jsonl(open("run.jsonl").read()),
+                           runner=lambda action: do(action))
+
+``record_step`` appends an indexed ``{step, observation, action[, result]}`` entry;
+``to_jsonl`` / ``from_jsonl`` round-trip the trace as newline-delimited JSON;
+``replay_trace`` runs each step's ``action`` through ``runner(action)`` and returns the
+``{step, action, result}`` outcomes in order.
+
+Executor command
+----------------
+
+``AC_replay_trace`` replays a ``trace`` (JSON array or JSONL) by running each step's
+``action`` (an AC action list) through the executor, returning ``{count, results}``. It
+is exposed as the MCP tool ``ac_replay_trace`` (side-effecting) and as a Script Builder
+command under **Flow**.

--- a/docs/source/Eng/doc/new_features/v155_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v155_features_doc.rst
@@ -1,0 +1,43 @@
+Geometry-Aware Element Diff & Stable IDs
+========================================
+
+``screen_state.diff_snapshots`` keys element identity strictly on ``(role, name)`` — so
+it cannot match an element whose label changed but position is stable, cannot track a
+renamed control, and cannot produce persistent IDs across frames. Geometry-aware
+matching (intersection-over-union, reusing :doc:`v138_features_doc`'s ``iou``) is the
+basis for stable element IDs an agent can refer to turn-over-turn: a button that moved
+a few pixels keeps its id, a renamed-but-stationary control matches by overlap, a
+genuinely new element gets a fresh id.
+
+Pure-stdlib over plain element dicts (``x`` / ``y`` / ``width`` / ``height``), so it is
+fully unit-testable. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import match_elements, assign_stable_ids
+
+    diff = match_elements(before_boxes, after_boxes, iou_threshold=0.5)
+    for pair in diff["matched"]:
+        print("moved/kept:", pair["before"], "->", pair["after"], pair["iou"])
+    print("appeared:", diff["added"], "disappeared:", diff["removed"])
+
+    # Carry stable IDs across frames so the agent can say "click element 7" reliably.
+    frame1 = assign_stable_ids(boxes1)
+    frame2 = assign_stable_ids(boxes2, prior=frame1)
+
+``match_elements`` greedily pairs ``before`` ↔ ``after`` by overlap, returning
+``{matched: [{before, after, iou}], added, removed}``. ``assign_stable_ids`` tags each
+element with an ``id``; with a ``prior`` frame each element inherits the id of the
+prior box it most overlaps (above ``iou_threshold``), and unmatched elements get fresh
+ids beyond the highest prior id.
+
+Executor commands
+-----------------
+
+``AC_match_elements`` (``before`` / ``after`` / ``iou_threshold`` → ``{matched, added,
+removed}``) and ``AC_assign_stable_ids`` (``elements`` / ``prior`` / ``iou_threshold``
+→ ``{count, elements}``). They are exposed as the MCP tools ``ac_match_elements`` /
+``ac_assign_stable_ids`` and as Script Builder commands under **Native UI**.

--- a/docs/source/Eng/doc/new_features/v156_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v156_features_doc.rst
@@ -1,0 +1,44 @@
+Weighted Candidate Scoring
+==========================
+
+``anchor_locator`` filters by a single spatial relation and sorts by distance, and
+``ab_locator`` races *whole strategies* and picks by elapsed time — neither is a
+*weighted multi-signal scorer* that ranks ambiguous candidates by combining a role
+match, a fuzzy name similarity, proximity to an anchor and enabled state into one
+confidence. That is exactly what self-healing / grounding needs when several boxes
+could be the target. The name similarity is injectable (defaulting to the project's
+``fuzzy_ratio``), so no new string-distance code is added.
+
+Pure-stdlib over plain element dicts (``role`` / ``name`` / ``x`` / ``y`` / ``width`` /
+``height`` / optional ``enabled``), fully unit-testable. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import score_candidates, best_candidate
+
+    ranked = score_candidates(candidates, want_role="button", want_name="Save",
+                              anchor=(960, 540))
+    for c in ranked:
+        print(round(c.score, 3), c.element["name"], c.matched_on)
+
+    pick = best_candidate(candidates, want_role="button", want_name="Save")
+    if pick:
+        click(*[pick.element["x"], pick.element["y"]])
+
+``score_candidates`` returns a list of ``ScoredCandidate`` (``element`` / ``score`` /
+``matched_on`` breakdown), best-first; each active signal contributes 0..1 and the
+score is their mean. ``want_role`` scores 1 on an exact role match, ``want_name`` runs
+``name_similarity`` (default ``fuzzy_ratio``), ``anchor`` adds a proximity term, and
+``prefer_enabled`` rewards enabled elements. ``best_candidate`` returns the top one (or
+``None``).
+
+Executor commands
+-----------------
+
+``AC_score_candidates`` (``candidates`` / ``want_role`` / ``want_name`` / ``anchor`` →
+``{count, scored}``) and ``AC_best_candidate`` (same inputs → ``{found, best}``). They
+are exposed as the MCP tools ``ac_score_candidates`` / ``ac_best_candidate`` and as
+Script Builder commands under **Native UI**.

--- a/docs/source/Eng/doc/new_features/v157_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v157_features_doc.rst
@@ -1,0 +1,43 @@
+Barcode Decoding (1-D)
+======================
+
+The framework already decodes QR codes (``read_qr``), but had no reader for the
+*1-D* barcodes (EAN-13 / EAN-8 / UPC-A / Code-128) that label physical goods,
+inventory tickets and shipping labels — the most common thing a desktop or kiosk
+automation needs to read off a product screen. ``read_barcodes`` fills that gap
+using OpenCV's ``cv2.barcode.BarcodeDetector``.
+
+The decode step is an **injectable seam**: the default decoder calls OpenCV, but
+tests (and alternative engines) can pass their own ``decoder`` callable, so the
+feature is fully unit-testable headlessly and degrades gracefully — a build of
+OpenCV without the ``barcode`` module simply returns an empty list instead of
+raising. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import read_barcodes
+
+    # decode every 1-D barcode currently on screen
+    for code in read_barcodes():
+        print(code["type"], code["text"], code["points"])
+
+    # restrict to a region, or decode a saved image instead of the screen
+    read_barcodes(region=[0, 0, 400, 200])
+    read_barcodes("label.png")
+
+``read_barcodes(source=None, *, region=None, decoder=None)`` returns a list of
+``{"text", "type", "points"}`` dicts, one per detected barcode (``points`` is the
+four-corner polygon in image coordinates). ``source`` may be an image path or an
+array; when omitted the screen (optionally cropped to ``region``) is grabbed. The
+grayscale conversion reuses the shared ``visual_match`` haystack loader, so no new
+image-loading code is added.
+
+Executor command
+----------------
+
+``AC_read_barcodes`` (``source`` / ``region`` → ``{count, barcodes}``) is exposed
+as the MCP tool ``ac_read_barcodes`` (read-only) and as a Script Builder command
+**Read Barcodes (1-D)** under **OCR**.

--- a/docs/source/Eng/doc/new_features/v158_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v158_features_doc.rst
@@ -1,0 +1,49 @@
+Rotation- and Scale-Tolerant Template Matching
+==============================================
+
+``match_template`` searches a template across *scales* (DPI / zoom tolerance) but
+assumes it is axis-aligned — OpenCV's ``matchTemplate`` is not rotation-invariant,
+so a control rendered at a slight skew, a rotated icon, or a dial/knob at a different
+angle is missed. ``match_rotated`` adds a rotation sweep: each angle is applied to
+the template with ``cv2.warpAffine``, crossed with a ``np.linspace`` scale-space, and
+the best-correlating (scale, angle) is returned — so the caller also learns the
+recovered *pose*.
+
+It reuses ``visual_match``'s grayscale loaders, scale resize, correlation-method
+table and non-maximum suppression, so no matching or geometry code is duplicated.
+The ``haystack`` is injectable (ndarray / path / PIL), so the search is unit-testable
+on synthetic arrays; only the default (grab the screen) is device-bound. Imports no
+``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import match_rotated, match_rotated_all, scale_space
+
+    # find a knob that may be turned to any of these angles, at any of these scales
+    hit = match_rotated("knob.png", angles=[-15, 0, 15, 30],
+                        scales=scale_space(0.9, 1.1, 3), min_score=0.85)
+    if hit:
+        print(hit.angle, hit.scale, hit.score, hit.center)
+
+    # every rotated occurrence, overlaps merged by NMS
+    for m in match_rotated_all("arrow.png", angles=[0, 90, 180, 270]):
+        print(m.center, m.angle)
+
+``match_rotated`` returns a single ``RotatedMatch`` (``x`` / ``y`` / ``width`` /
+``height`` / ``score`` / ``scale`` / ``angle`` + ``center``) or ``None``;
+``match_rotated_all`` returns every hit at or above ``min_score`` with overlapping
+detections from neighbouring angles / scales collapsed by NMS, ordered by score.
+``scale_space(min, max, steps)`` is a helper returning evenly spaced scales.
+
+Executor commands
+-----------------
+
+``AC_match_rotated`` (``template`` / ``min_score`` / ``angles`` / ``scales`` /
+``region`` / ``method`` → ``{found, match}``) and ``AC_match_rotated_all`` (adds
+``max_results`` / ``nms_iou`` → ``{count, matches}``). They are exposed as the MCP
+tools ``ac_match_rotated`` / ``ac_match_rotated_all`` (read-only) and as Script
+Builder commands **Match Template (rotated)** / **Match Template All (rotated)**
+under **Image**.

--- a/docs/source/Eng/doc/new_features/v159_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v159_features_doc.rst
@@ -1,0 +1,47 @@
+Coarse Labelled Screen Grid (VLM Grounding)
+===========================================
+
+Vision / VLM grounding works far better when a model can refer to a *coarse cell*
+("click cell C3") than to raw pixel coordinates, which it tends to hallucinate — a
+labelled overlay grid is the standard way to describe a screenshot to such a model and
+to map its answer back to a point. The framework had no such helper. ``screen_grid``
+lays an ``rows`` x ``cols`` grid over the screen (or a sub-``region``), labels each cell
+spreadsheet-style (column letter + row number, ``A1`` top-left) and converts both ways.
+
+Pure-stdlib geometry; the only device-bound path is the default that grabs the live
+screen size when neither ``region`` nor ``screen_size`` is given, so every function is
+fully unit-testable by passing an explicit region. Imports no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import grid_cells, cell_for_point, point_for_cell, click
+
+    # describe the screen to a model as a 4x4 grid
+    for cell in grid_cells(4, 4):
+        print(cell.label, cell.center)
+
+    # the model answers "C3" -> turn it into a click
+    click(*point_for_cell("C3", 4, 4))
+
+    # which cell did the user click in?
+    cell = cell_for_point(820, 410, 4, 4)
+    print(cell.label if cell else "outside")
+
+``grid_cells(rows, cols, *, region=None, screen_size=None)`` returns row-major
+``GridCell`` objects (``label`` / ``row`` / ``col`` / ``left`` / ``top`` / ``right`` /
+``bottom`` + ``center``). ``cell_for_point`` returns the containing cell (or ``None`` if
+the point is outside the region); ``point_for_cell`` returns the centre ``[x, y]`` of a
+named cell, ready to click. Labels run past ``Z`` spreadsheet-style (``AA``, ``AB`` …).
+
+Executor commands
+-----------------
+
+``AC_grid_cells`` (``rows`` / ``cols`` / ``region`` → ``{count, cells}``),
+``AC_cell_for_point`` (``x`` / ``y`` / ``rows`` / ``cols`` / ``region`` →
+``{found, cell}``) and ``AC_point_for_cell`` (``label`` / ``rows`` / ``cols`` /
+``region`` → ``{point}``). They are exposed as the MCP tools ``ac_grid_cells`` /
+``ac_cell_for_point`` / ``ac_point_for_cell`` (read-only) and as Script Builder
+commands under **Image**.

--- a/docs/source/Eng/doc/new_features/v160_features_doc.rst
+++ b/docs/source/Eng/doc/new_features/v160_features_doc.rst
@@ -1,0 +1,44 @@
+Clipboard File-Drop List (CF_HDROP)
+===================================
+
+The clipboard layer carried text and images, and ``rich_clipboard`` added HTML, but the
+framework could never put a *list of files* on the clipboard — the ``CF_HDROP`` payload
+Explorer reads when you copy files and ``Ctrl+V`` them elsewhere as a real file copy.
+Building that blob is fiddly: a fixed 20-byte ``DROPFILES`` header followed by a
+double-null-terminated (UTF-16 by default) path list, with the header's ``pFiles`` offset
+pointing at the list. ``clipboard_files`` isolates that error-prone packing.
+
+The packing lives in pure, fully unit-testable ``build_dropfiles`` / ``parse_dropfiles``
+byte functions (no device, any platform), with thin Windows-only ``set_clipboard_files`` /
+``get_clipboard_files`` wrappers on top — the same split ``rich_clipboard`` uses for
+``CF_HTML``. The pure functions import no ``PySide6``.
+
+Headless API
+------------
+
+.. code-block:: python
+
+    from je_auto_control import (build_dropfiles, parse_dropfiles,
+                                 set_clipboard_files, get_clipboard_files)
+
+    # put two files on the clipboard, ready to paste into Explorer (Windows)
+    set_clipboard_files([r"C:\reports\q1.pdf", r"C:\reports\q2.pdf"])
+    print(get_clipboard_files())
+
+    # the byte layer is testable without a clipboard at all
+    blob = build_dropfiles([r"C:\a\one.txt"], point=(10, 20))
+    assert parse_dropfiles(blob)["paths"] == [r"C:\a\one.txt"]
+
+``build_dropfiles(paths, *, point=(0, 0), wide=True, non_client=False)`` returns the raw
+``DROPFILES`` bytes; ``parse_dropfiles`` reverses it into
+``{paths, point, wide, non_client}``. ``set_clipboard_files`` / ``get_clipboard_files`` put
+and read the list via the Windows clipboard (``get`` returns ``None`` when no file list is
+present).
+
+Executor commands
+-----------------
+
+``AC_set_clipboard_files`` (``paths`` → ``{set, count}``) and ``AC_get_clipboard_files``
+(→ ``{found, paths}``). They are exposed as the MCP tools ``ac_set_clipboard_files`` /
+``ac_get_clipboard_files`` and as Script Builder commands **Set Clipboard Files** /
+**Get Clipboard Files** under **Data**.

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -180,6 +180,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v155_features_doc
    doc/new_features/v156_features_doc
    doc/new_features/v157_features_doc
+   doc/new_features/v158_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -182,6 +182,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v157_features_doc
    doc/new_features/v158_features_doc
    doc/new_features/v159_features_doc
+   doc/new_features/v160_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -173,6 +173,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v148_features_doc
    doc/new_features/v149_features_doc
    doc/new_features/v150_features_doc
+   doc/new_features/v151_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -178,6 +178,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v153_features_doc
    doc/new_features/v154_features_doc
    doc/new_features/v155_features_doc
+   doc/new_features/v156_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -172,6 +172,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v147_features_doc
    doc/new_features/v148_features_doc
    doc/new_features/v149_features_doc
+   doc/new_features/v150_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -181,6 +181,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v156_features_doc
    doc/new_features/v157_features_doc
    doc/new_features/v158_features_doc
+   doc/new_features/v159_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -176,6 +176,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v151_features_doc
    doc/new_features/v152_features_doc
    doc/new_features/v153_features_doc
+   doc/new_features/v154_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -168,6 +168,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v143_features_doc
    doc/new_features/v144_features_doc
    doc/new_features/v145_features_doc
+   doc/new_features/v146_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -174,6 +174,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v149_features_doc
    doc/new_features/v150_features_doc
    doc/new_features/v151_features_doc
+   doc/new_features/v152_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -170,6 +170,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v145_features_doc
    doc/new_features/v146_features_doc
    doc/new_features/v147_features_doc
+   doc/new_features/v148_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -167,6 +167,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v142_features_doc
    doc/new_features/v143_features_doc
    doc/new_features/v144_features_doc
+   doc/new_features/v145_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -177,6 +177,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v152_features_doc
    doc/new_features/v153_features_doc
    doc/new_features/v154_features_doc
+   doc/new_features/v155_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -175,6 +175,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v150_features_doc
    doc/new_features/v151_features_doc
    doc/new_features/v152_features_doc
+   doc/new_features/v153_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -179,6 +179,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v154_features_doc
    doc/new_features/v155_features_doc
    doc/new_features/v156_features_doc
+   doc/new_features/v157_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -169,6 +169,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v144_features_doc
    doc/new_features/v145_features_doc
    doc/new_features/v146_features_doc
+   doc/new_features/v147_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Eng/eng_index.rst
+++ b/docs/source/Eng/eng_index.rst
@@ -171,6 +171,7 @@ Comprehensive guides for all AutoControl features.
    doc/new_features/v146_features_doc
    doc/new_features/v147_features_doc
    doc/new_features/v148_features_doc
+   doc/new_features/v149_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/doc/new_features/v145_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v145_features_doc.rst
@@ -1,0 +1,36 @@
+色彩直方圖指紋與變化偵測
+========================
+
+``image_dedup`` 以感知 aHash / dHash 做指紋——那是*空間性*的 64 位元雜湊,對顏色與主題變化很脆弱——而
+``color_stats`` 只回傳單一平均 / 主要顏色。正規化的色彩*直方圖*是判斷「這是不是同一個畫面、調色盤是否改變」的標準
+耐光照、耐縮放訊號:主題切換、內容重載、旋轉的橫幅——這些雜湊與單一主色都捕捉不到。
+
+每個函式都在可注入的影像(ndarray / 路徑 / PIL,RGB)上執行,因此可對合成陣列做無頭測試。``cv2.calcHist`` /
+``cv2.compareHist`` 屬於 OpenCV 核心;OpenCV + NumPy 透過 ``je_open_cv`` 引入。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import (image_histogram, compare_histograms,
+                                 histogram_changed)
+
+    baseline = image_histogram("golden.png")          # 3 * bins 個浮點數(HSV)
+    if histogram_changed("golden.png"):               # current = 實際螢幕
+        print("the view changed")
+
+    score = compare_histograms(baseline, image_histogram())   # 1.0 == 完全相同
+
+``image_histogram`` 回傳逐通道正規化直方圖的平面清單(``space`` = ``hsv`` / ``rgb`` / ``gray``;每通道貢獻
+``bins`` 個值)。``compare_histograms`` 支援 ``correlation`` / ``chisqr`` / ``intersection`` /
+``bhattacharyya``(correlation / intersection 越高越相似;距離方法越高越不同)。``histogram_changed`` 比較
+``reference`` 與 ``current``(預設為螢幕)並回傳布林值,會依相似 vs 距離方法自動翻轉門檻比較方向。
+
+執行器命令
+----------
+
+``AC_image_histogram``(``source`` / ``bins`` / ``space`` / ``region`` → ``{bins, space, histogram}``)與
+``AC_histogram_changed``(``reference`` / ``current`` / ``method`` / ``threshold`` / ``space`` / ``region`` →
+``{changed, score}``)。它們以 MCP 工具 ``ac_image_histogram`` / ``ac_histogram_changed`` 以及 Script Builder 中
+**Image** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v146_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v146_features_doc.rst
@@ -1,0 +1,37 @@
+局部動態 / 活動偵測
+====================
+
+三個相近鄰居,各有區別:``wait_until_screen_stable`` 在即時輪詢迴圈上回傳*布林值*(不是對可注入配對的局部方框);
+``ssim_changed_regions`` 是*結構性*的(高斯視窗 SSIM、耐光照——刻意忽略你想抓的快速像素動態);``diff_screenshots``
+標示像素差但不以活動區塊 + 分數呈現。``changed_regions`` / ``has_motion`` / ``activity_score`` 是便宜的 absdiff
+路徑:兩幀之間哪些子區域在*移動*,讓腳本能挑選安靜區域或定位忙碌的轉圈動畫。
+
+它們在兩個可注入的幀(ndarray / 路徑 / PIL)上運作,因此可對合成陣列做無頭測試,並沿用共用的連通元件輔助函式。
+OpenCV + NumPy 透過 ``je_open_cv`` 引入。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import changed_regions, has_motion, activity_score
+
+    before = screenshot_to_array()
+    # ... 經過一段時間 ...
+    for box in changed_regions(before, after):     # 移動的方框,由大到小
+        print(box["x"], box["y"], box["width"], box["height"])
+
+    if has_motion(before, after):
+        print("still animating, activity =", activity_score(before, after))
+
+``changed_regions`` 對絕對差做門檻(``threshold``)、去噪(``blur``)、膨脹,回傳至少 ``min_area`` 的
+``{x, y, width, height, area, center}`` 區塊,由大到小。``has_motion`` 是布林形式;``activity_score`` 是移動像素的
+比例(0..1)。不同尺寸的幀會丟出 ``ValueError``。
+
+執行器命令
+----------
+
+``AC_changed_regions``(``before`` / ``after`` / ``threshold`` / ``min_area`` / ``blur`` → ``{count, regions}``)與
+``AC_has_motion``(``before`` / ``after`` / ``threshold`` / ``min_area`` → ``{moved, activity}``);``after`` 預設為
+即時螢幕擷取。它們以 MCP 工具 ``ac_changed_regions`` / ``ac_has_motion`` 以及 Script Builder 中 **Image** 分類下的
+命令提供。

--- a/docs/source/Zh/doc/new_features/v147_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v147_features_doc.rst
@@ -1,0 +1,35 @@
+視窗 Z-order——置頂 / 移到最前 / 移到最後
+=========================================
+
+``windows_window_manage.set_window_position`` 在原始 Win32 層存在,但未在套件 facade 匯出、沒有以標題為基礎的包裝、
+也沒有 topmost / not-topmost 語意——而 GUI 疊圖以外的地方完全沒有 ``always_on_top``。本功能加入標準 RPA z-order
+基本能力:純函式 ``plan_zorder`` 將動作對應到 ``SetWindowPos`` 的 insert-after 常數,以及以標題操作、可注入 driver
+的 ``set_topmost`` / ``bring_to_front`` / ``send_to_back``(與 ``snap_window`` 相同的接縫模式)。
+
+規劃為純函式且可無頭測試;只有預設 driver 觸及 Win32(其他平台回傳 ``False``)。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import (set_topmost, bring_to_front, send_to_back,
+                                 plan_zorder)
+
+    set_topmost("Media Player")          # 置頂
+    set_topmost("Media Player", False)   # 取消置頂
+    bring_to_front("Editor")
+    send_to_back("Background Monitor")
+
+    plan_zorder("topmost")["insert_after"]   # -1(HWND_TOPMOST),純 / 可測
+
+``plan_zorder(action)``(``top`` / ``bottom`` / ``topmost`` / ``notopmost``)回傳 ``SetWindowPos`` 描述符
+(``insert_after`` 常數 + ``SWP_NOMOVE`` / ``SWP_NOSIZE`` 旗標);未知動作丟出 ``ValueError``。``set_topmost`` /
+``bring_to_front`` / ``send_to_back`` 以標題解析視窗並透過預設 Win32 driver(測試時注入)套用動作,回傳是否已套用。
+
+執行器命令
+----------
+
+``AC_set_topmost``(``title`` / ``on`` → ``{applied}``)、``AC_bring_to_front`` 與 ``AC_send_to_back``
+(``title`` → ``{applied}``)。它們以 MCP 工具 ``ac_set_topmost`` / ``ac_bring_to_front`` / ``ac_send_to_back``
+以及 Script Builder 中 **Window** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v148_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v148_features_doc.rst
@@ -1,0 +1,34 @@
+軟性斷言——區塊結束時彙整所有失敗
+====================================
+
+``assertion.assert_all`` 接受**事先建好的規格字典清單**。沒有一個可以在交錯動作之間隨處呼叫 ``check()``、並在退出時
+一次拋出全部的*作用域累加器*——也就是 JUnit5 ``assertAll`` / Playwright ``expect.soft`` / AssertJ ``SoftAssertions``
+模式,是驗證表單眾多欄位而不在第一個失敗就停下的標準寫法。
+
+純標準函式庫的 context manager;不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import SoftAssertions
+
+    with SoftAssertions() as soft:
+        soft.check(title == "Invoice", "wrong title")
+        soft.check_equal(total, "$42.00", "wrong total")
+        soft.check(date_field_is_visible(), "date field missing")
+    # 退出時一次拋出列出每一個失敗的檢查(全部通過則不拋)
+
+``check(condition, message)`` 記錄通過/失敗且永不拋出(回傳布林值,可據以分支);``check_equal(actual, expected,
+message)`` 是相等捷徑。``failures`` 列出失敗訊息、``passed`` 計算通過數、``assert_all()`` 彙整後丟出
+``AutoControlActionException``。context manager 在乾淨退出時呼叫 ``assert_all``(且永不遮蔽已在傳播的例外)。
+傳入 ``raise_on_exit=False`` 可只收集不自動拋出。
+
+執行器命令
+----------
+
+``AC_soft_assert`` 評估一串 ``checks``(每個為 ``{value, op, expected, message}``,``op`` =
+``eq`` / ``ne`` / ``gt`` / ``lt`` / ``contains`` / ``truthy``)並回傳 ``{ok, passed, failures}``——回報*所有*失敗,
+不只第一個;設 ``raise_on_fail`` 則改為拋出。它以 MCP 工具 ``ac_soft_assert`` 以及 Script Builder 中 **Flow**
+分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v149_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v149_features_doc.rst
@@ -1,0 +1,35 @@
+感知式(YIQ)影像比對含反鋸齒抑制
+====================================
+
+``visual_regression.image_difference`` 計算原始逐通道最大差像素數,``ssim_compare`` 給出整體結構分數。兩者都未使用
+*感知式*色彩度量,也都不忽略**反鋸齒邊緣**——那是跨 DPI 與字體微調時視覺比對誤報的首要來源。``perceptual_diff``
+在 YIQ 空間比較像素(pixelmatch 的色彩度量,比 RGB 更接近人眼感知),並預設移除反鋸齒造成的單像素細邊差異
+(形態學開運算),因此只計算*實心*變化區域。
+
+在可注入的影像配對(ndarray / 路徑 / PIL)上執行,因此可對合成陣列做無頭測試。OpenCV + NumPy 透過 ``je_open_cv``
+引入;沿用共用的連通元件輔助與 RGB 載入器。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import perceptual_diff, assert_perceptual
+
+    result = perceptual_diff("actual.png", "golden.png", threshold=0.1)
+    print(result.diff_pixels, result.diff_ratio, result.regions)
+
+    # 把關視覺回歸測試(超出比例則拋例外)。
+    assert_perceptual("actual.png", "golden.png", max_diff_ratio=0.01)
+
+``perceptual_diff`` 回傳 ``PerceptualDiffResult``(``diff_pixels``、``total_pixels``、``diff_ratio``,以及變化叢集
+的 ``regions`` 方框)。``threshold``(0..1)是 pixelmatch 靈敏度。``include_aa=True`` 會保留細邊差異而不抑制。
+``assert_perceptual`` 在 ``diff_ratio`` 超過 ``max_diff_ratio`` 時丟出 ``AutoControlActionException``。不同尺寸的
+影像會丟出 ``ValueError``。
+
+執行器命令
+----------
+
+``AC_perceptual_diff``(``actual`` / ``expected`` / ``threshold`` / ``include_aa`` / ``max_diff_ratio`` →
+``{diff_pixels, total_pixels, diff_ratio, regions}``;給定 ``max_diff_ratio`` 且超出時拋例外)。它以 MCP 工具
+``ac_perceptual_diff`` 以及 Script Builder 中 **Image** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v150_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v150_features_doc.rst
@@ -1,0 +1,36 @@
+視窗客戶區幾何
+==============
+
+``window_capture.get_window_geometry`` 回傳視窗的*外框*邊界框(供截圖),但沒有*客戶區*矩形、沒有框邊內縮運算、
+也沒有客戶區→螢幕的點對應。RPA 需要「不論標題列高度 / 邊框,在此視窗客戶區的 ``(x, y)`` 點擊」——這是視窗相對
+點擊的基礎。本功能加入客戶區矩形、純框邊內縮與客戶區轉螢幕輔助函式,以及一次呼叫的 ``client_point``。
+
+``frame_insets`` / ``client_to_screen`` 是純幾何(可無頭測試);只有 ``get_client_rect`` 的預設讀取器觸及 Win32
+(``GetClientRect`` + ``ClientToScreen``),且可注入。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import (get_client_rect, client_point, frame_insets,
+                                 client_to_screen)
+
+    # 從視窗內容原點(非標題列)往內 20px、往下 30px 點擊。
+    point = client_point("Calculator", 20, 30)
+    if point:
+        click(*point)
+
+    rect = get_client_rect("Calculator")               # (x, y, width, height)
+    insets = frame_insets(get_window_geometry("Calculator"), rect)  # 邊框大小
+
+``get_client_rect`` 以螢幕座標原點回傳客戶區的 ``(x, y, width, height)``(或 ``None``);``client_point`` 把客戶區
+區域內的點對應到螢幕,讓點擊不論視窗外框都落在內容上。``frame_insets`` 由外框與客戶區矩形回傳
+``{left, top, right, bottom}`` 邊框 / 標題列厚度,``client_to_screen`` 則是底層的純位移。
+
+執行器命令
+----------
+
+``AC_get_client_rect``(``title`` → ``{found, rect}``)與 ``AC_client_point``(``title`` / ``x`` / ``y`` →
+``{found, point}``)。它們以 MCP 工具 ``ac_get_client_rect`` / ``ac_client_point`` 以及 Script Builder 中 **Window**
+分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v151_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v151_features_doc.rst
@@ -1,0 +1,39 @@
+標準化 Computer-Use 動作結構
+============================
+
+``tool_use_schema`` 把 AC_* 命令*簽章*匯出為工具定義,``coordinate_space`` 縮放模型網格——但兩者都不*正規化進來的
+動作酬載*。Anthropic 的 computer-use 工具發出 ``{action:"left_click", coordinate:[x,y]}``,OpenAI 的 CUA 發出
+``{type:"click", x, y, button}``——先前沒有把這些異質形狀對應到標準動作、再對應到可執行 AC_* 命令的轉接器,
+整合者只能手寫膠水程式。
+
+純標準函式庫的字典對應(選用 ``scale`` callable 套用座標空間縮放),完全可無頭測試。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import (from_anthropic, from_openai_cua, to_ac_command,
+                                 canonical_action)
+
+    # Anthropic agent 輸出 -> 標準 -> 可執行 AC 動作。
+    canonical = from_anthropic({"action": "left_click", "coordinate": [120, 80]})
+    command = to_ac_command(canonical)
+    # -> ["AC_click_mouse", {"mouse_keycode": "mouse_left", "x": 120, "y": 80}]
+
+    # OpenAI CUA,含 模型->實體 座標縮放。
+    cmd = to_ac_command(from_openai_cua({"type": "scroll", "x": 5, "y": 6,
+                                         "scroll_y": 120}),
+                        scale=lambda x, y: (x * 2, y * 2))
+
+``from_anthropic`` / ``from_openai_cua`` 把各供應商酬載對應為標準 ``{type, x, y, text, …}``(click、double/right/
+middle click、move、type、key、scroll、screenshot)。``to_ac_command`` 把標準動作對應為 ``[command_name, params]``
+AC 動作(``AC_click_mouse`` / ``AC_set_mouse_position`` / ``AC_write`` / ``AC_hotkey`` / ``AC_mouse_scroll`` /
+``AC_screenshot``),並對座標套用 ``scale``;無法對應的類型會丟出 ``AutoControlActionException``。``canonical_action``
+直接建立標準字典。
+
+執行器命令
+----------
+
+``AC_cua_command`` 從 ``source``(``anthropic`` / ``openai`` / ``canonical``)正規化 ``payload`` 並回傳
+``{canonical, command}``。它以 MCP 工具 ``ac_cua_command`` 以及 Script Builder 中 **Native UI** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v152_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v152_features_doc.rst
@@ -1,0 +1,38 @@
+符記預算內的無障礙文字觀測
+============================
+
+``screen_state.describe_screen`` 回傳角色*數量*加上控制項標籤的平面清單——但沒有穩定的逐元素索引、沒有
+``[12] button "Submit" @(x,y)`` 行、沒有視口裁切,也沒有元素上限 / 符記預算。現代桌面與網頁 agent 餵入*扁平化、
+已編號、依視口修剪*的文字區塊(「無障礙樹作為文字觀測」模式),再依索引操作(「click [12]」)。本功能建立該觀測
+與其背後的索引,與 :doc:`v138_features_doc` 及 ``set_of_marks`` 搭配。
+
+純標準函式庫,作用於純元素字典(``role`` / ``name`` / ``x`` / ``y`` / ``width`` / ``height``,可含巢狀
+``children``),因此完全可單元測試。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import (serialize_observation, observation_index,
+                                 flatten_tree)
+
+    text = serialize_observation(a11y_tree, viewport=(0, 0, 1920, 1080),
+                                 max_elements=60)
+    # [0] button "Save" @(30,20)
+    # [1] textbox "Search" @(140,20)
+    # ... 把 `text` 餵給模型;它回覆「click [1]」
+
+    target = observation_index(a11y_tree)[1]      # [1] 背後的結構化元素
+    click(*[target["x"] + target["width"] // 2, target["y"] + target["height"] // 2])
+
+``flatten_tree`` 扁平化巢狀元素樹,預設只保留互動角色。``observation_index`` 裁切到 ``viewport``、由上到下 /
+由左到右排序、上限 ``max_elements`` 並指派穩定 ``index``。``serialize_observation`` 將其渲染為
+``[i] role "name" @(cx,cy)`` 行。
+
+執行器命令
+----------
+
+``AC_serialize_observation``(``elements`` / ``viewport`` / ``max_elements`` → ``{observation, count}``)與
+``AC_observation_index``(相同輸入 → ``{count, elements}``)。它們以 MCP 工具 ``ac_serialize_observation`` /
+``ac_observation_index`` 以及 Script Builder 中 **Native UI** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v153_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v153_features_doc.rst
@@ -1,0 +1,33 @@
+動作前接地防護
+==============
+
+``guardrail`` 掃描文字找提示注入、``loop_guard`` 偵測卡住的迴圈——但兩者都不在派發前驗證*座標動作*。agent 迴圈會
+執行模型回傳的任何東西,毫無邊界或目標檢查,因此幻覺出的 ``(9999, -5)`` 點擊會打到空處,而偏 5 像素的點擊會錯過
+按鈕。``validate_action`` 加入「執行前偵測錯位動作」防護:拒絕螢幕外點擊,並把接近但偏離的座標吸附到最近已知元素
+的中心。
+
+純標準函式庫幾何,作用於純元素字典(``x`` / ``y`` / ``width`` / ``height``),因此完全可單元測試。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import validate_action, snap_to_element, in_bounds
+
+    check = validate_action(model_action, screen_size=(1920, 1080), targets=elements)
+    if not check["ok"]:
+        print("rejected:", check["reason"])         # 例如 "out of bounds"
+    else:
+        x, y = check["snapped"] or (model_action["x"], model_action["y"])
+        click(x, y)                                  # 已吸附到真正的按鈕
+
+``in_bounds(x, y, screen_size)`` 是螢幕邊界判斷式;``snap_to_element`` 回傳某點所在(或在 ``max_dist`` 內最近)
+元素的中心,否則 ``None``;``validate_action`` 結合兩者,回傳 ``{ok, reason, snapped}``——拒絕越界座標,並在提供
+``targets`` 時吸附接近偏離者。沒有座標的動作一律通過。
+
+執行器命令
+----------
+
+``AC_validate_action``(``action`` / ``screen`` / ``targets`` → ``{ok, reason, snapped}``;``screen`` 預設為實際
+螢幕)。它以 MCP 工具 ``ac_validate_action`` 以及 Script Builder 中 **Native UI** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v154_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v154_features_doc.rst
@@ -1,0 +1,38 @@
+可攜式 Agent 軌跡記錄(錄製與重播)
+====================================
+
+``agent_trace`` 記錄 OpenTelemetry GenAI *span*(符記 / 延遲 / 成本)——那是觀測性,不是可重播的觀測→動作轉錄;
+``trajectory_eval`` *評分*軌跡但未定義持久格式也無法重播;``semantic_recording`` 重播錄製的*人類輸入巨集*,而非
+*agent* 決策。本功能加入 OmniTool 風格的「記錄軌跡以建立重播 / 訓練資料集」格式:``{step, observation, action,
+result}`` JSONL,加上決定性的重播驅動器。
+
+純標準函式庫 JSONL;重播驅動器接受可注入的 ``runner``(無需即時模型),因此完全可單元測試。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import record_step, to_jsonl, from_jsonl, replay_trace
+
+    trace = []
+    record_step(trace, observation="login screen",
+                action=["AC_click_mouse", {"x": 120, "y": 80}])
+    record_step(trace, observation="typed user", action=["AC_write",
+                {"write_string": "alice"}], result={"ok": True})
+
+    open("run.jsonl", "w").write(to_jsonl(trace))     # 持久化資料集
+
+    # 之後——透過任意 runner 重播每一步(此處為測試用 fake)。
+    results = replay_trace(from_jsonl(open("run.jsonl").read()),
+                           runner=lambda action: do(action))
+
+``record_step`` 附加一個有索引的 ``{step, observation, action[, result]}`` 條目;``to_jsonl`` / ``from_jsonl`` 以
+換行分隔 JSON 往返;``replay_trace`` 透過 ``runner(action)`` 執行每一步的 ``action``,並依序回傳
+``{step, action, result}`` 結果。
+
+執行器命令
+----------
+
+``AC_replay_trace`` 透過執行器執行每一步的 ``action``(AC 動作清單)來重播 ``trace``(JSON 陣列或 JSONL),回傳
+``{count, results}``。它以 MCP 工具 ``ac_replay_trace``(有副作用)以及 Script Builder 中 **Flow** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v155_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v155_features_doc.rst
@@ -1,0 +1,36 @@
+幾何感知的元素差異與穩定 ID
+============================
+
+``screen_state.diff_snapshots`` 嚴格以 ``(role, name)`` 作為元素識別——因此無法比對標籤變了但位置穩定的元素、無法
+追蹤改名的控制項,也無法跨影格產生持久 ID。幾何感知比對(交集除以聯集,沿用 :doc:`v138_features_doc` 的 ``iou``)
+是 agent 能跨回合引用穩定元素 ID 的基礎:移動幾像素的按鈕保留其 id、改名但未移動的控制項以重疊比對到、真正
+新增的元素取得新 id。
+
+純標準函式庫,作用於純元素字典(``x`` / ``y`` / ``width`` / ``height``),因此完全可單元測試。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import match_elements, assign_stable_ids
+
+    diff = match_elements(before_boxes, after_boxes, iou_threshold=0.5)
+    for pair in diff["matched"]:
+        print("moved/kept:", pair["before"], "->", pair["after"], pair["iou"])
+    print("appeared:", diff["added"], "disappeared:", diff["removed"])
+
+    # 跨影格延續穩定 ID,讓 agent 能可靠地說「click element 7」。
+    frame1 = assign_stable_ids(boxes1)
+    frame2 = assign_stable_ids(boxes2, prior=frame1)
+
+``match_elements`` 以重疊貪婪配對 ``before`` ↔ ``after``,回傳 ``{matched: [{before, after, iou}], added, removed}``。
+``assign_stable_ids`` 為每個元素標上 ``id``;給定 ``prior`` 影格時,每個元素繼承其最重疊(超過 ``iou_threshold``)
+之 prior 框的 id,未配對者取得超過最大 prior id 的新 id。
+
+執行器命令
+----------
+
+``AC_match_elements``(``before`` / ``after`` / ``iou_threshold`` → ``{matched, added, removed}``)與
+``AC_assign_stable_ids``(``elements`` / ``prior`` / ``iou_threshold`` → ``{count, elements}``)。它們以 MCP 工具
+``ac_match_elements`` / ``ac_assign_stable_ids`` 以及 Script Builder 中 **Native UI** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v156_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v156_features_doc.rst
@@ -1,0 +1,37 @@
+加權候選評分
+============
+
+``anchor_locator`` 以單一空間關係過濾、依距離排序,``ab_locator`` 競賽*整個策略*並依耗時挑選——兩者都不是把角色
+匹配、模糊名稱相似度、對錨點的鄰近度與啟用狀態合成單一信心的*加權多訊號評分器*。當多個框都可能是目標時,
+自我修復 / grounding 正需要這個。名稱相似度可注入(預設為專案的 ``fuzzy_ratio``),因此不新增字串距離程式。
+
+純標準函式庫,作用於純元素字典(``role`` / ``name`` / ``x`` / ``y`` / ``width`` / ``height`` / 選用 ``enabled``),
+完全可單元測試。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import score_candidates, best_candidate
+
+    ranked = score_candidates(candidates, want_role="button", want_name="Save",
+                              anchor=(960, 540))
+    for c in ranked:
+        print(round(c.score, 3), c.element["name"], c.matched_on)
+
+    pick = best_candidate(candidates, want_role="button", want_name="Save")
+    if pick:
+        click(*[pick.element["x"], pick.element["y"]])
+
+``score_candidates`` 回傳 ``ScoredCandidate`` 清單(``element`` / ``score`` / ``matched_on`` 明細),最佳優先;每個
+啟用的訊號貢獻 0..1,分數為其平均。``want_role`` 在角色精確匹配時得 1、``want_name`` 執行 ``name_similarity``
+(預設 ``fuzzy_ratio``)、``anchor`` 加入鄰近項、``prefer_enabled`` 獎勵啟用元素。``best_candidate`` 回傳最佳者
+(或 ``None``)。
+
+執行器命令
+----------
+
+``AC_score_candidates``(``candidates`` / ``want_role`` / ``want_name`` / ``anchor`` → ``{count, scored}``)與
+``AC_best_candidate``(相同輸入 → ``{found, best}``)。它們以 MCP 工具 ``ac_score_candidates`` / ``ac_best_candidate``
+以及 Script Builder 中 **Native UI** 分類下的命令提供。

--- a/docs/source/Zh/doc/new_features/v157_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v157_features_doc.rst
@@ -1,0 +1,40 @@
+一維條碼解碼
+============
+
+框架已能解碼 QR Code（``read_qr``），但缺少能讀取 *一維* 條碼（EAN-13 / EAN-8 /
+UPC-A / Code-128）的功能——這些正是商品、庫存標籤與物流面單上最常見的條碼，也是
+桌面或自助機自動化最需要從商品畫面讀取的資訊。``read_barcodes`` 透過 OpenCV 的
+``cv2.barcode.BarcodeDetector`` 補上這一塊。
+
+解碼步驟是一個**可注入接縫**：預設解碼器呼叫 OpenCV，但測試（或其他引擎）可以傳入
+自己的 ``decoder`` 可呼叫物件，因此此功能可在無頭環境下完整單元測試，且能優雅降級
+——若 OpenCV 編譯時未含 ``barcode`` 模組，僅回傳空清單而非拋出例外。不匯入
+``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import read_barcodes
+
+    # 解碼螢幕上目前所有一維條碼
+    for code in read_barcodes():
+        print(code["type"], code["text"], code["points"])
+
+    # 限定區域，或改為解碼已存檔的影像
+    read_barcodes(region=[0, 0, 400, 200])
+    read_barcodes("label.png")
+
+``read_barcodes(source=None, *, region=None, decoder=None)`` 回傳
+``{"text", "type", "points"}`` 字典清單，每偵測到一個條碼一筆（``points`` 為影像
+座標中的四角多邊形）。``source`` 可為影像路徑或陣列；省略時擷取螢幕（可選擇以
+``region`` 裁切）。灰階轉換重用共用的 ``visual_match`` haystack 載入器，不新增
+影像載入程式碼。
+
+執行器指令
+----------
+
+``AC_read_barcodes``（``source`` / ``region`` → ``{count, barcodes}``）以 MCP 工具
+``ac_read_barcodes``（唯讀）及 Script Builder 指令 **Read Barcodes (1-D)**（位於
+**OCR** 分類下）形式提供。

--- a/docs/source/Zh/doc/new_features/v158_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v158_features_doc.rst
@@ -1,0 +1,44 @@
+旋轉與縮放容忍的樣板比對
+========================
+
+``match_template`` 能跨*縮放*搜尋樣板(容忍 DPI / 縮放),但假設樣板為軸對齊——
+OpenCV 的 ``matchTemplate`` 不具旋轉不變性,因此略為傾斜的控制項、旋轉的圖示,或
+轉到不同角度的旋鈕 / 刻度盤都會比對失敗。``match_rotated`` 加入旋轉掃描:每個角度
+以 ``cv2.warpAffine`` 套用到樣板上,並與 ``np.linspace`` 縮放空間交叉,回傳相關性
+最高的(scale, angle)——因此呼叫端也能得知還原出的*姿態*。
+
+本功能重用 ``visual_match`` 的灰階載入器、縮放 resize、相關性方法表與非極大值抑制,
+不重複任何比對或幾何程式。``haystack`` 可注入(ndarray / 路徑 / PIL),因此搜尋可在
+合成陣列上單元測試;只有預設(擷取螢幕)為裝置相依。不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import match_rotated, match_rotated_all, scale_space
+
+    # 尋找可能轉到任一角度、任一縮放的旋鈕
+    hit = match_rotated("knob.png", angles=[-15, 0, 15, 30],
+                        scales=scale_space(0.9, 1.1, 3), min_score=0.85)
+    if hit:
+        print(hit.angle, hit.scale, hit.score, hit.center)
+
+    # 每個旋轉後的出現位置,重疊以 NMS 合併
+    for m in match_rotated_all("arrow.png", angles=[0, 90, 180, 270]):
+        print(m.center, m.angle)
+
+``match_rotated`` 回傳單一 ``RotatedMatch``(``x`` / ``y`` / ``width`` / ``height`` /
+``score`` / ``scale`` / ``angle`` + ``center``)或 ``None``;``match_rotated_all``
+回傳所有達到 ``min_score`` 的命中,相鄰角度 / 縮放的重疊偵測以 NMS 合併,依分數排序。
+``scale_space(min, max, steps)`` 為回傳等間距縮放的輔助函式。
+
+執行器指令
+----------
+
+``AC_match_rotated``(``template`` / ``min_score`` / ``angles`` / ``scales`` /
+``region`` / ``method`` → ``{found, match}``)與 ``AC_match_rotated_all``(另加
+``max_results`` / ``nms_iou`` → ``{count, matches}``)。兩者以 MCP 工具
+``ac_match_rotated`` / ``ac_match_rotated_all``(唯讀)及 Script Builder 指令
+**Match Template (rotated)** / **Match Template All (rotated)**(位於 **Image**
+分類下)形式提供。

--- a/docs/source/Zh/doc/new_features/v159_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v159_features_doc.rst
@@ -1,0 +1,45 @@
+粗粒度標籤螢幕網格(VLM Grounding)
+==================================
+
+視覺 / VLM grounding 在模型能引用*粗粒度儲存格*(「點擊 C3 格」)時,遠比引用容易
+幻覺的原始像素座標更可靠——疊加標籤網格正是向此類模型描述截圖、並將其回答對應回
+座標點的標準做法。框架先前沒有這個輔助工具。``screen_grid`` 在螢幕(或子 ``region``)
+上鋪設 ``rows`` x ``cols`` 網格,以試算表風格標記每個儲存格(欄字母 + 列號,左上為
+``A1``),並雙向轉換。
+
+純標準函式庫幾何;唯一裝置相依的路徑是當未提供 ``region`` 或 ``screen_size`` 時抓取
+即時螢幕尺寸的預設行為,因此每個函式都可透過傳入明確區域完整單元測試。不匯入
+``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import grid_cells, cell_for_point, point_for_cell, click
+
+    # 以 4x4 網格向模型描述螢幕
+    for cell in grid_cells(4, 4):
+        print(cell.label, cell.center)
+
+    # 模型回答「C3」-> 轉成點擊
+    click(*point_for_cell("C3", 4, 4))
+
+    # 使用者點在哪個儲存格?
+    cell = cell_for_point(820, 410, 4, 4)
+    print(cell.label if cell else "outside")
+
+``grid_cells(rows, cols, *, region=None, screen_size=None)`` 回傳列優先的
+``GridCell`` 物件(``label`` / ``row`` / ``col`` / ``left`` / ``top`` / ``right`` /
+``bottom`` + ``center``)。``cell_for_point`` 回傳包含該點的儲存格(點在區域外則回傳
+``None``);``point_for_cell`` 回傳指定儲存格的中心 ``[x, y]``,可直接點擊。標籤超過
+``Z`` 後以試算表風格延續(``AA``、``AB`` …)。
+
+執行器指令
+----------
+
+``AC_grid_cells``(``rows`` / ``cols`` / ``region`` → ``{count, cells}``)、
+``AC_cell_for_point``(``x`` / ``y`` / ``rows`` / ``cols`` / ``region`` →
+``{found, cell}``)與 ``AC_point_for_cell``(``label`` / ``rows`` / ``cols`` /
+``region`` → ``{point}``)。三者以 MCP 工具 ``ac_grid_cells`` / ``ac_cell_for_point`` /
+``ac_point_for_cell``(唯讀)及 Script Builder 指令(位於 **Image** 分類下)形式提供。

--- a/docs/source/Zh/doc/new_features/v160_features_doc.rst
+++ b/docs/source/Zh/doc/new_features/v160_features_doc.rst
@@ -1,0 +1,42 @@
+剪貼簿檔案拖放清單(CF_HDROP)
+==============================
+
+剪貼簿層原本能承載文字與影像,``rich_clipboard`` 又加入了 HTML,但框架始終無法把一份
+*檔案清單*放上剪貼簿——也就是當你複製檔案後在他處 ``Ctrl+V`` 進行真正的檔案複製時,
+Explorer 讀取的 ``CF_HDROP`` 內容。建構這個位元組區塊相當瑣碎:一個固定 20 位元組的
+``DROPFILES`` 標頭,後接以雙重 null 結尾(預設 UTF-16)的路徑清單,且標頭的 ``pFiles``
+位移需指向該清單。``clipboard_files`` 將這段容易出錯的封裝獨立出來。
+
+封裝邏輯位於純粹、可完整單元測試的 ``build_dropfiles`` / ``parse_dropfiles`` 位元組函式
+(不需裝置、任何平台皆可),其上再疊加僅限 Windows 的 ``set_clipboard_files`` /
+``get_clipboard_files`` 薄包裝——與 ``rich_clipboard`` 處理 ``CF_HTML`` 的拆分方式相同。
+純函式不匯入 ``PySide6``。
+
+無頭 API
+--------
+
+.. code-block:: python
+
+    from je_auto_control import (build_dropfiles, parse_dropfiles,
+                                 set_clipboard_files, get_clipboard_files)
+
+    # 將兩個檔案放上剪貼簿,可貼進 Explorer(Windows)
+    set_clipboard_files([r"C:\reports\q1.pdf", r"C:\reports\q2.pdf"])
+    print(get_clipboard_files())
+
+    # 位元組層完全不需剪貼簿即可測試
+    blob = build_dropfiles([r"C:\a\one.txt"], point=(10, 20))
+    assert parse_dropfiles(blob)["paths"] == [r"C:\a\one.txt"]
+
+``build_dropfiles(paths, *, point=(0, 0), wide=True, non_client=False)`` 回傳原始
+``DROPFILES`` 位元組;``parse_dropfiles`` 將其還原為 ``{paths, point, wide, non_client}``。
+``set_clipboard_files`` / ``get_clipboard_files`` 透過 Windows 剪貼簿寫入與讀取該清單
+(無檔案清單時 ``get`` 回傳 ``None``)。
+
+執行器指令
+----------
+
+``AC_set_clipboard_files``(``paths`` → ``{set, count}``)與 ``AC_get_clipboard_files``
+(→ ``{found, paths}``)。兩者以 MCP 工具 ``ac_set_clipboard_files`` /
+``ac_get_clipboard_files`` 及 Script Builder 指令 **Set Clipboard Files** /
+**Get Clipboard Files**(位於 **Data** 分類下)形式提供。

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -182,6 +182,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v157_features_doc
    doc/new_features/v158_features_doc
    doc/new_features/v159_features_doc
+   doc/new_features/v160_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -167,6 +167,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v142_features_doc
    doc/new_features/v143_features_doc
    doc/new_features/v144_features_doc
+   doc/new_features/v145_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -169,6 +169,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v144_features_doc
    doc/new_features/v145_features_doc
    doc/new_features/v146_features_doc
+   doc/new_features/v147_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -174,6 +174,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v149_features_doc
    doc/new_features/v150_features_doc
    doc/new_features/v151_features_doc
+   doc/new_features/v152_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -170,6 +170,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v145_features_doc
    doc/new_features/v146_features_doc
    doc/new_features/v147_features_doc
+   doc/new_features/v148_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -176,6 +176,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v151_features_doc
    doc/new_features/v152_features_doc
    doc/new_features/v153_features_doc
+   doc/new_features/v154_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -171,6 +171,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v146_features_doc
    doc/new_features/v147_features_doc
    doc/new_features/v148_features_doc
+   doc/new_features/v149_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -177,6 +177,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v152_features_doc
    doc/new_features/v153_features_doc
    doc/new_features/v154_features_doc
+   doc/new_features/v155_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -175,6 +175,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v150_features_doc
    doc/new_features/v151_features_doc
    doc/new_features/v152_features_doc
+   doc/new_features/v153_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -168,6 +168,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v143_features_doc
    doc/new_features/v144_features_doc
    doc/new_features/v145_features_doc
+   doc/new_features/v146_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -172,6 +172,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v147_features_doc
    doc/new_features/v148_features_doc
    doc/new_features/v149_features_doc
+   doc/new_features/v150_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -181,6 +181,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v156_features_doc
    doc/new_features/v157_features_doc
    doc/new_features/v158_features_doc
+   doc/new_features/v159_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -173,6 +173,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v148_features_doc
    doc/new_features/v149_features_doc
    doc/new_features/v150_features_doc
+   doc/new_features/v151_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -179,6 +179,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v154_features_doc
    doc/new_features/v155_features_doc
    doc/new_features/v156_features_doc
+   doc/new_features/v157_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -178,6 +178,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v153_features_doc
    doc/new_features/v154_features_doc
    doc/new_features/v155_features_doc
+   doc/new_features/v156_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/docs/source/Zh/zh_index.rst
+++ b/docs/source/Zh/zh_index.rst
@@ -180,6 +180,7 @@ AutoControl 所有功能的完整使用指南。
    doc/new_features/v155_features_doc
    doc/new_features/v156_features_doc
    doc/new_features/v157_features_doc
+   doc/new_features/v158_features_doc
    doc/ocr_backends/ocr_backends_doc
    doc/observability/observability_doc
    doc/operations_layer/operations_layer_doc

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -369,6 +369,10 @@ from je_auto_control.utils.cua_action import (
 from je_auto_control.utils.observation import (
     flatten_tree, observation_index, serialize_observation,
 )
+# Pre-action grounding guard (bounds check + snap-to-element)
+from je_auto_control.utils.action_grounding import (
+    in_bounds, snap_to_element, validate_action,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1250,6 +1254,9 @@ __all__ = [
     "flatten_tree",
     "observation_index",
     "serialize_observation",
+    "in_bounds",
+    "snap_to_element",
+    "validate_action",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -365,6 +365,10 @@ from je_auto_control.utils.window_geometry import (
 from je_auto_control.utils.cua_action import (
     canonical_action, from_anthropic, from_openai_cua, to_ac_command,
 )
+# Token-budgeted, indexed a11y text observation for VLM/agent grounding
+from je_auto_control.utils.observation import (
+    flatten_tree, observation_index, serialize_observation,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1243,6 +1247,9 @@ __all__ = [
     "from_anthropic",
     "from_openai_cua",
     "to_ac_command",
+    "flatten_tree",
+    "observation_index",
+    "serialize_observation",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -347,6 +347,10 @@ from je_auto_control.utils.locator_chain import Candidates, from_boxes
 from je_auto_control.utils.rich_clipboard import (
     build_cf_html, get_clipboard_html, parse_cf_html, set_clipboard_html,
 )
+# Clipboard file-drop list (CF_HDROP): pure DROPFILES packing + Win32 set/get
+from je_auto_control.utils.clipboard_files import (
+    build_dropfiles, get_clipboard_files, parse_dropfiles, set_clipboard_files,
+)
 # Colour-histogram fingerprint & change detection (illumination-robust)
 from je_auto_control.utils.img_histogram import (
     compare_histograms, histogram_changed, image_histogram,
@@ -1259,6 +1263,10 @@ __all__ = [
     "parse_cf_html",
     "get_clipboard_html",
     "set_clipboard_html",
+    "build_dropfiles",
+    "parse_dropfiles",
+    "set_clipboard_files",
+    "get_clipboard_files",
     "image_histogram",
     "compare_histograms",
     "histogram_changed",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -381,6 +381,10 @@ from je_auto_control.utils.agent_replay import (
 from je_auto_control.utils.element_diff import (
     assign_stable_ids, match_elements,
 )
+# Weighted candidate scoring (role + name similarity + proximity + enabled)
+from je_auto_control.utils.element_scoring import (
+    ScoredCandidate, best_candidate, score_candidates,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1271,6 +1275,9 @@ __all__ = [
     "replay_trace",
     "match_elements",
     "assign_stable_ids",
+    "score_candidates",
+    "best_candidate",
+    "ScoredCandidate",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -373,6 +373,10 @@ from je_auto_control.utils.observation import (
 from je_auto_control.utils.action_grounding import (
     in_bounds, snap_to_element, validate_action,
 )
+# Portable agent-trajectory trace (record observation->action steps, replay)
+from je_auto_control.utils.agent_replay import (
+    from_jsonl, record_step, replay_trace, to_jsonl,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1257,6 +1261,10 @@ __all__ = [
     "in_bounds",
     "snap_to_element",
     "validate_action",
+    "record_step",
+    "to_jsonl",
+    "from_jsonl",
+    "replay_trace",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -343,6 +343,10 @@ from je_auto_control.utils.rich_clipboard import (
 from je_auto_control.utils.img_histogram import (
     compare_histograms, histogram_changed, image_histogram,
 )
+# Localized change / activity detection between two frames (absdiff)
+from je_auto_control.utils.motion_regions import (
+    activity_score, changed_regions, has_motion,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1202,6 +1206,9 @@ __all__ = [
     "image_histogram",
     "compare_histograms",
     "histogram_changed",
+    "changed_regions",
+    "has_motion",
+    "activity_score",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -377,6 +377,10 @@ from je_auto_control.utils.action_grounding import (
 from je_auto_control.utils.agent_replay import (
     from_jsonl, record_step, replay_trace, to_jsonl,
 )
+# Geometry-aware element matching across frames (stable IDs, move tracking)
+from je_auto_control.utils.element_diff import (
+    assign_stable_ids, match_elements,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1265,6 +1269,8 @@ __all__ = [
     "to_jsonl",
     "from_jsonl",
     "replay_trace",
+    "match_elements",
+    "assign_stable_ids",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -385,6 +385,8 @@ from je_auto_control.utils.element_diff import (
 from je_auto_control.utils.element_scoring import (
     ScoredCandidate, best_candidate, score_candidates,
 )
+# 1-D barcode decoding (EAN / UPC) with an injectable decoder seam
+from je_auto_control.utils.barcode import read_barcodes
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1278,6 +1280,7 @@ __all__ = [
     "score_candidates",
     "best_candidate",
     "ScoredCandidate",
+    "read_barcodes",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -279,6 +279,10 @@ from je_auto_control.utils.visual_match import (
     match_template_all,
 )
 from je_auto_control.utils.visual_match import Match as TemplateMatch
+# Rotation- and scale-tolerant template matching (scale-space x angle sweep)
+from je_auto_control.utils.rotated_match import (
+    RotatedMatch, match_rotated, match_rotated_all, scale_space,
+)
 # Locate on-screen regions by colour (mask + connected components)
 from je_auto_control.utils.color_region import (
     find_color_region, find_color_regions,
@@ -1182,6 +1186,10 @@ __all__ = [
     "match_masked",
     "match_masked_all",
     "best_matches",
+    "RotatedMatch",
+    "match_rotated",
+    "match_rotated_all",
+    "scale_space",
     "find_color_region",
     "find_color_regions",
     "ssim_compare",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -339,6 +339,10 @@ from je_auto_control.utils.locator_chain import Candidates, from_boxes
 from je_auto_control.utils.rich_clipboard import (
     build_cf_html, get_clipboard_html, parse_cf_html, set_clipboard_html,
 )
+# Colour-histogram fingerprint & change detection (illumination-robust)
+from je_auto_control.utils.img_histogram import (
+    compare_histograms, histogram_changed, image_histogram,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1195,6 +1199,9 @@ __all__ = [
     "parse_cf_html",
     "get_clipboard_html",
     "set_clipboard_html",
+    "image_histogram",
+    "compare_histograms",
+    "histogram_changed",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -361,6 +361,10 @@ from je_auto_control.utils.perceptual_diff import (
 from je_auto_control.utils.window_geometry import (
     client_point, client_to_screen, frame_insets, get_client_rect,
 )
+# Canonical computer-use action schema (normalize Anthropic / OpenAI -> AC_*)
+from je_auto_control.utils.cua_action import (
+    canonical_action, from_anthropic, from_openai_cua, to_ac_command,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1235,6 +1239,10 @@ __all__ = [
     "client_to_screen",
     "get_client_rect",
     "client_point",
+    "canonical_action",
+    "from_anthropic",
+    "from_openai_cua",
+    "to_ac_command",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -357,6 +357,10 @@ from je_auto_control.utils.soft_assert import SoftAssertions
 from je_auto_control.utils.perceptual_diff import (
     PerceptualDiffResult, assert_perceptual, perceptual_diff,
 )
+# Window client-area geometry (frame insets, client-to-screen mapping)
+from je_auto_control.utils.window_geometry import (
+    client_point, client_to_screen, frame_insets, get_client_rect,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1227,6 +1231,10 @@ __all__ = [
     "perceptual_diff",
     "assert_perceptual",
     "PerceptualDiffResult",
+    "frame_insets",
+    "client_to_screen",
+    "get_client_rect",
+    "client_point",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -351,6 +351,8 @@ from je_auto_control.utils.motion_regions import (
 from je_auto_control.utils.window_zorder import (
     bring_to_front, plan_zorder, send_to_back, set_topmost,
 )
+# Soft assertions (accumulate checks, raise the aggregate at block end)
+from je_auto_control.utils.soft_assert import SoftAssertions
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1217,6 +1219,7 @@ __all__ = [
     "set_topmost",
     "bring_to_front",
     "send_to_back",
+    "SoftAssertions",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -347,6 +347,10 @@ from je_auto_control.utils.img_histogram import (
 from je_auto_control.utils.motion_regions import (
     activity_score, changed_regions, has_motion,
 )
+# Window z-order control (topmost / bring-to-front / send-to-back)
+from je_auto_control.utils.window_zorder import (
+    bring_to_front, plan_zorder, send_to_back, set_topmost,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1209,6 +1213,10 @@ __all__ = [
     "changed_regions",
     "has_motion",
     "activity_score",
+    "plan_zorder",
+    "set_topmost",
+    "bring_to_front",
+    "send_to_back",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -353,6 +353,10 @@ from je_auto_control.utils.window_zorder import (
 )
 # Soft assertions (accumulate checks, raise the aggregate at block end)
 from je_auto_control.utils.soft_assert import SoftAssertions
+# Perceptual (YIQ) image diff with anti-alias edge suppression
+from je_auto_control.utils.perceptual_diff import (
+    PerceptualDiffResult, assert_perceptual, perceptual_diff,
+)
 # CI workflow annotations (GitHub Actions)
 from je_auto_control.utils.ci_annotations import (
     emit_annotations, format_annotation,
@@ -1220,6 +1224,9 @@ __all__ = [
     "bring_to_front",
     "send_to_back",
     "SoftAssertions",
+    "perceptual_diff",
+    "assert_perceptual",
+    "PerceptualDiffResult",
     "emit_annotations", "format_annotation",
     "ClipboardHistory", "default_clipboard_history",
     "analyze_heal_log", "heal_stats", "scan_secrets",

--- a/je_auto_control/__init__.py
+++ b/je_auto_control/__init__.py
@@ -283,6 +283,10 @@ from je_auto_control.utils.visual_match import Match as TemplateMatch
 from je_auto_control.utils.rotated_match import (
     RotatedMatch, match_rotated, match_rotated_all, scale_space,
 )
+# Coarse labelled cell grid for VLM grounding (point <-> cell mapping)
+from je_auto_control.utils.screen_grid import (
+    GridCell, cell_for_point, grid_cells, point_for_cell,
+)
 # Locate on-screen regions by colour (mask + connected components)
 from je_auto_control.utils.color_region import (
     find_color_region, find_color_regions,
@@ -1190,6 +1194,10 @@ __all__ = [
     "match_rotated",
     "match_rotated_all",
     "scale_space",
+    "GridCell",
+    "grid_cells",
+    "cell_for_point",
+    "point_for_cell",
     "find_color_region",
     "find_color_regions",
     "ssim_compare",

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -863,6 +863,16 @@ def _add_flow_specs(specs: List[CommandSpec]) -> None:
         description="Re-run an action until a key of its result matches.",
     ))
     specs.append(CommandSpec(
+        "AC_soft_assert", "Flow", "Soft Assert (aggregate)",
+        fields=(
+            FieldSpec("checks", FieldType.STRING,
+                      placeholder='[{"value":5,"op":"gt","expected":3}]'),
+            FieldSpec("raise_on_fail", FieldType.BOOL, optional=True,
+                      default=False),
+        ),
+        description="Aggregate many checks and report all failures (not just first).",
+    ))
+    specs.append(CommandSpec(
         "AC_wait_pixel", "Flow", "Wait for Pixel",
         fields=(
             FieldSpec("x", FieldType.INT),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -336,6 +336,39 @@ def _add_image_specs(specs: List[CommandSpec]) -> None:
         description="Find every rotation/scale-tolerant match (NMS-deduped).",
     ))
     specs.append(CommandSpec(
+        "AC_grid_cells", "Image", "Grid Cells (coarse grounding)",
+        fields=(
+            FieldSpec("rows", FieldType.INT, optional=True, default=3),
+            FieldSpec("cols", FieldType.INT, optional=True, default=3),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Label an rows x cols grid over the screen for VLM grounding.",
+    ))
+    specs.append(CommandSpec(
+        "AC_cell_for_point", "Image", "Cell For Point",
+        fields=(
+            FieldSpec("x", FieldType.INT),
+            FieldSpec("y", FieldType.INT),
+            FieldSpec("rows", FieldType.INT, optional=True, default=3),
+            FieldSpec("cols", FieldType.INT, optional=True, default=3),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Return the grid cell label containing a screen point.",
+    ))
+    specs.append(CommandSpec(
+        "AC_point_for_cell", "Image", "Point For Cell",
+        fields=(
+            FieldSpec("label", FieldType.STRING, placeholder="C3"),
+            FieldSpec("rows", FieldType.INT, optional=True, default=3),
+            FieldSpec("cols", FieldType.INT, optional=True, default=3),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Return the centre point of a named grid cell (click target).",
+    ))
+    specs.append(CommandSpec(
         "AC_find_color_region", "Image", "Find Colour Region",
         fields=(
             FieldSpec("rgb", FieldType.STRING, placeholder="[0, 200, 0]"),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -2921,6 +2921,28 @@ def _add_set_of_marks_specs(specs: List[CommandSpec]) -> None:
         description="Map an Anthropic / OpenAI computer-use action to an AC command.",
     ))
     specs.append(CommandSpec(
+        "AC_serialize_observation", "Native UI", "Observation: Serialize Elements",
+        fields=(
+            FieldSpec("elements", FieldType.STRING,
+                      placeholder='[{"role":"button","name":"OK","x":..,"y":..}]'),
+            FieldSpec("viewport", FieldType.STRING, optional=True,
+                      placeholder="[x, y, w, h]"),
+            FieldSpec("max_elements", FieldType.INT, optional=True, default=80),
+        ),
+        description="Indexed text observation of UI elements for a VLM (act by index).",
+    ))
+    specs.append(CommandSpec(
+        "AC_observation_index", "Native UI", "Observation: Index Elements",
+        fields=(
+            FieldSpec("elements", FieldType.STRING,
+                      placeholder='[{"role":"button","name":"OK","x":..,"y":..}]'),
+            FieldSpec("viewport", FieldType.STRING, optional=True,
+                      placeholder="[x, y, w, h]"),
+            FieldSpec("max_elements", FieldType.INT, optional=True, default=80),
+        ),
+        description="Reading-ordered, viewport-clipped, indexed element list.",
+    ))
+    specs.append(CommandSpec(
         "AC_mark_screen", "Native UI", "Set-of-Marks: Number Elements",
         fields=(
             FieldSpec("app_name", FieldType.STRING, optional=True),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -900,6 +900,14 @@ def _add_flow_specs(specs: List[CommandSpec]) -> None:
         description="Aggregate many checks and report all failures (not just first).",
     ))
     specs.append(CommandSpec(
+        "AC_replay_trace", "Flow", "Replay Agent Trace",
+        fields=(
+            FieldSpec("trace", FieldType.STRING,
+                      placeholder='[{"action":["AC_click_mouse",{...}]}]'),
+        ),
+        description="Replay a recorded trajectory's actions through the executor.",
+    ))
+    specs.append(CommandSpec(
         "AC_wait_pixel", "Flow", "Wait for Pixel",
         fields=(
             FieldSpec("x", FieldType.INT),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -502,6 +502,36 @@ def _add_image_specs(specs: List[CommandSpec]) -> None:
         ),
         description="Refine candidate boxes (within / filter / reading / nth / …).",
     ))
+    specs.append(CommandSpec(
+        "AC_image_histogram", "Image", "Image Histogram",
+        fields=(
+            FieldSpec("source", FieldType.FILE_PATH, optional=True),
+            FieldSpec("bins", FieldType.INT, optional=True, default=32),
+            FieldSpec("space", FieldType.ENUM, optional=True, default="hsv",
+                      choices=("hsv", "rgb", "gray")),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Colour-histogram fingerprint of an image / the screen.",
+    ))
+    specs.append(CommandSpec(
+        "AC_histogram_changed", "Image", "Histogram Changed?",
+        fields=(
+            FieldSpec("reference", FieldType.FILE_PATH),
+            FieldSpec("current", FieldType.FILE_PATH, optional=True),
+            FieldSpec("method", FieldType.ENUM, optional=True,
+                      default="correlation",
+                      choices=("correlation", "chisqr", "intersection",
+                               "bhattacharyya")),
+            FieldSpec("threshold", FieldType.FLOAT, optional=True, default=0.9,
+                      min_value=0.0, max_value=1.0),
+            FieldSpec("space", FieldType.ENUM, optional=True, default="hsv",
+                      choices=("hsv", "rgb", "gray")),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Detect a palette/view change vs a reference (illumination-robust).",
+    ))
 
 
 def _add_ocr_specs(specs: List[CommandSpec]) -> None:

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -2964,6 +2964,30 @@ def _add_set_of_marks_specs(specs: List[CommandSpec]) -> None:
                     "element.",
     ))
     specs.append(CommandSpec(
+        "AC_match_elements", "Native UI", "Match Elements (frames)",
+        fields=(
+            FieldSpec("before", FieldType.STRING,
+                      placeholder='[{"x":..,"y":..,"width":..,"height":..}]'),
+            FieldSpec("after", FieldType.STRING,
+                      placeholder='[{"x":..,"y":..,"width":..,"height":..}]'),
+            FieldSpec("iou_threshold", FieldType.FLOAT, optional=True, default=0.5,
+                      min_value=0.0, max_value=1.0),
+        ),
+        description="Match element boxes across two frames by overlap (move/rename).",
+    ))
+    specs.append(CommandSpec(
+        "AC_assign_stable_ids", "Native UI", "Assign Stable Element IDs",
+        fields=(
+            FieldSpec("elements", FieldType.STRING,
+                      placeholder='[{"x":..,"y":..,"width":..,"height":..}]'),
+            FieldSpec("prior", FieldType.STRING, optional=True,
+                      placeholder="prior frame's elements (with ids)"),
+            FieldSpec("iou_threshold", FieldType.FLOAT, optional=True, default=0.5,
+                      min_value=0.0, max_value=1.0),
+        ),
+        description="Tag elements with IDs carried across frames by overlap.",
+    ))
+    specs.append(CommandSpec(
         "AC_mark_screen", "Native UI", "Set-of-Marks: Number Elements",
         fields=(
             FieldSpec("app_name", FieldType.STRING, optional=True),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -532,6 +532,27 @@ def _add_image_specs(specs: List[CommandSpec]) -> None:
         ),
         description="Detect a palette/view change vs a reference (illumination-robust).",
     ))
+    specs.append(CommandSpec(
+        "AC_changed_regions", "Image", "Changed Regions (motion)",
+        fields=(
+            FieldSpec("before", FieldType.FILE_PATH),
+            FieldSpec("after", FieldType.FILE_PATH, optional=True),
+            FieldSpec("threshold", FieldType.INT, optional=True, default=25),
+            FieldSpec("min_area", FieldType.INT, optional=True, default=80),
+            FieldSpec("blur", FieldType.INT, optional=True, default=5),
+        ),
+        description="Boxes of regions that moved between two frames (after=screen).",
+    ))
+    specs.append(CommandSpec(
+        "AC_has_motion", "Image", "Has Motion?",
+        fields=(
+            FieldSpec("before", FieldType.FILE_PATH),
+            FieldSpec("after", FieldType.FILE_PATH, optional=True),
+            FieldSpec("threshold", FieldType.INT, optional=True, default=25),
+            FieldSpec("min_area", FieldType.INT, optional=True, default=80),
+        ),
+        description="Whether anything moved between two frames (+ activity score).",
+    ))
 
 
 def _add_ocr_specs(specs: List[CommandSpec]) -> None:

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -2943,6 +2943,19 @@ def _add_set_of_marks_specs(specs: List[CommandSpec]) -> None:
         description="Reading-ordered, viewport-clipped, indexed element list.",
     ))
     specs.append(CommandSpec(
+        "AC_validate_action", "Native UI", "Validate / Snap Action",
+        fields=(
+            FieldSpec("action", FieldType.STRING,
+                      placeholder='{"type":"click","x":..,"y":..}'),
+            FieldSpec("screen", FieldType.STRING, optional=True,
+                      placeholder="[width, height]"),
+            FieldSpec("targets", FieldType.STRING, optional=True,
+                      placeholder='[{"x":..,"y":..,"width":..,"height":..}]'),
+        ),
+        description="Reject out-of-bounds clicks; snap a near-miss to the nearest "
+                    "element.",
+    ))
+    specs.append(CommandSpec(
         "AC_mark_screen", "Native UI", "Set-of-Marks: Number Elements",
         fields=(
             FieldSpec("app_name", FieldType.STRING, optional=True),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -677,6 +677,24 @@ def _add_window_specs(specs: List[CommandSpec]) -> None:
         description="Cascade a list of windows diagonally.",
     ))
     specs.append(CommandSpec(
+        "AC_set_topmost", "Window", "Set Always-On-Top",
+        fields=(
+            FieldSpec("title", FieldType.STRING),
+            FieldSpec("on", FieldType.BOOL, optional=True, default=True),
+        ),
+        description="Pin a window always-on-top (or release it).",
+    ))
+    specs.append(CommandSpec(
+        "AC_bring_to_front", "Window", "Bring Window to Front",
+        fields=(FieldSpec("title", FieldType.STRING),),
+        description="Raise a window to the top of the z-order.",
+    ))
+    specs.append(CommandSpec(
+        "AC_send_to_back", "Window", "Send Window to Back",
+        fields=(FieldSpec("title", FieldType.STRING),),
+        description="Send a window to the bottom of the z-order.",
+    ))
+    specs.append(CommandSpec(
         "AC_wait_window_closed", "Window", "Wait for Window to Close",
         fields=(
             FieldSpec("title", FieldType.STRING),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -2911,6 +2911,16 @@ def _add_screen_state_specs(specs: List[CommandSpec]) -> None:
 
 def _add_set_of_marks_specs(specs: List[CommandSpec]) -> None:
     specs.append(CommandSpec(
+        "AC_cua_command", "Native UI", "Computer-Use: Map Action",
+        fields=(
+            FieldSpec("payload", FieldType.STRING,
+                      placeholder='{"action":"left_click","coordinate":[x,y]}'),
+            FieldSpec("source", FieldType.ENUM, optional=True, default="canonical",
+                      choices=("canonical", "anthropic", "openai")),
+        ),
+        description="Map an Anthropic / OpenAI computer-use action to an AC command.",
+    ))
+    specs.append(CommandSpec(
         "AC_mark_screen", "Native UI", "Set-of-Marks: Number Elements",
         fields=(
             FieldSpec("app_name", FieldType.STRING, optional=True),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -587,6 +587,15 @@ def _add_ocr_specs(specs: List[CommandSpec]) -> None:
         description="Decode QR codes in a screen region (OpenCV).",
     ))
     specs.append(CommandSpec(
+        "AC_read_barcodes", "OCR", "Read Barcodes (1-D)",
+        fields=(
+            FieldSpec("source", FieldType.FILE_PATH, optional=True),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Decode 1-D barcodes (EAN / UPC) in an image / screen region.",
+    ))
+    specs.append(CommandSpec(
         "AC_scroll_to_find", "OCR", "Scroll Until Visible",
         fields=(
             FieldSpec("target", FieldType.STRING),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -2988,6 +2988,30 @@ def _add_set_of_marks_specs(specs: List[CommandSpec]) -> None:
         description="Tag elements with IDs carried across frames by overlap.",
     ))
     specs.append(CommandSpec(
+        "AC_score_candidates", "Native UI", "Score Candidates",
+        fields=(
+            FieldSpec("candidates", FieldType.STRING,
+                      placeholder='[{"role":"button","name":"OK","x":..,"y":..}]'),
+            FieldSpec("want_role", FieldType.STRING, optional=True),
+            FieldSpec("want_name", FieldType.STRING, optional=True),
+            FieldSpec("anchor", FieldType.STRING, optional=True,
+                      placeholder="[x, y]"),
+        ),
+        description="Rank candidate elements by role / name / proximity confidence.",
+    ))
+    specs.append(CommandSpec(
+        "AC_best_candidate", "Native UI", "Best Candidate",
+        fields=(
+            FieldSpec("candidates", FieldType.STRING,
+                      placeholder='[{"role":"button","name":"OK","x":..,"y":..}]'),
+            FieldSpec("want_role", FieldType.STRING, optional=True),
+            FieldSpec("want_name", FieldType.STRING, optional=True),
+            FieldSpec("anchor", FieldType.STRING, optional=True,
+                      placeholder="[x, y]"),
+        ),
+        description="The single highest-scoring candidate element.",
+    ))
+    specs.append(CommandSpec(
         "AC_mark_screen", "Native UI", "Set-of-Marks: Number Elements",
         fields=(
             FieldSpec("app_name", FieldType.STRING, optional=True),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -1245,6 +1245,18 @@ def _add_misc_specs(specs: List[CommandSpec]) -> None:
         description="Read the clipboard's HTML fragment (CF_HTML, Windows).",
     ))
     specs.append(CommandSpec(
+        "AC_set_clipboard_files", "Data", "Set Clipboard Files",
+        fields=(
+            FieldSpec("paths", FieldType.STRING,
+                      placeholder='["C:\\\\a\\\\one.txt", "C:\\\\b\\\\two.png"]'),
+        ),
+        description="Put a file-drop list on the clipboard (CF_HDROP, Windows).",
+    ))
+    specs.append(CommandSpec(
+        "AC_get_clipboard_files", "Data", "Get Clipboard Files",
+        description="Read the clipboard's file-drop list (CF_HDROP, Windows).",
+    ))
+    specs.append(CommandSpec(
         "AC_watchdog_add", "Flow", "Watchdog: Add Popup Rule",
         fields=(
             FieldSpec("title", FieldType.STRING),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -708,6 +708,20 @@ def _add_window_specs(specs: List[CommandSpec]) -> None:
         description="Send a window to the bottom of the z-order.",
     ))
     specs.append(CommandSpec(
+        "AC_get_client_rect", "Window", "Get Client Rect",
+        fields=(FieldSpec("title", FieldType.STRING),),
+        description="A window's client-area rect (excludes title bar / borders).",
+    ))
+    specs.append(CommandSpec(
+        "AC_client_point", "Window", "Client-Relative Point",
+        fields=(
+            FieldSpec("title", FieldType.STRING),
+            FieldSpec("x", FieldType.INT),
+            FieldSpec("y", FieldType.INT),
+        ),
+        description="Screen point for an (x, y) inside a window's client area.",
+    ))
+    specs.append(CommandSpec(
         "AC_wait_window_closed", "Window", "Wait for Window to Close",
         fields=(
             FieldSpec("title", FieldType.STRING),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -305,6 +305,37 @@ def _add_image_specs(specs: List[CommandSpec]) -> None:
         description="Find every masked match of a template (NMS-deduped).",
     ))
     specs.append(CommandSpec(
+        "AC_match_rotated", "Image", "Match Template (rotated)",
+        fields=(
+            FieldSpec("template", FieldType.FILE_PATH),
+            FieldSpec("min_score", FieldType.FLOAT, optional=True, default=0.8,
+                      min_value=0.0, max_value=1.0),
+            FieldSpec("angles", FieldType.STRING, optional=True,
+                      placeholder="[-10, 0, 10]"),
+            FieldSpec("scales", FieldType.STRING, optional=True,
+                      placeholder="[0.9, 1.0, 1.1]"),
+            FieldSpec("region", FieldType.STRING, optional=True,
+                      placeholder=_REGION_PLACEHOLDER),
+        ),
+        description="Locate a template tolerating rotation + scale; reports angle.",
+    ))
+    specs.append(CommandSpec(
+        "AC_match_rotated_all", "Image", "Match Template All (rotated)",
+        fields=(
+            FieldSpec("template", FieldType.FILE_PATH),
+            FieldSpec("min_score", FieldType.FLOAT, optional=True, default=0.8,
+                      min_value=0.0, max_value=1.0),
+            FieldSpec("angles", FieldType.STRING, optional=True,
+                      placeholder="[-10, 0, 10]"),
+            FieldSpec("scales", FieldType.STRING, optional=True,
+                      placeholder="[0.9, 1.0, 1.1]"),
+            FieldSpec("max_results", FieldType.INT, optional=True, default=20),
+            FieldSpec("nms_iou", FieldType.FLOAT, optional=True, default=0.3,
+                      min_value=0.0, max_value=1.0),
+        ),
+        description="Find every rotation/scale-tolerant match (NMS-deduped).",
+    ))
+    specs.append(CommandSpec(
         "AC_find_color_region", "Image", "Find Colour Region",
         fields=(
             FieldSpec("rgb", FieldType.STRING, placeholder="[0, 200, 0]"),

--- a/je_auto_control/gui/script_builder/command_schema.py
+++ b/je_auto_control/gui/script_builder/command_schema.py
@@ -553,6 +553,19 @@ def _add_image_specs(specs: List[CommandSpec]) -> None:
         ),
         description="Whether anything moved between two frames (+ activity score).",
     ))
+    specs.append(CommandSpec(
+        "AC_perceptual_diff", "Image", "Perceptual Diff (YIQ)",
+        fields=(
+            FieldSpec("actual", FieldType.FILE_PATH),
+            FieldSpec("expected", FieldType.FILE_PATH),
+            FieldSpec("threshold", FieldType.FLOAT, optional=True, default=0.1,
+                      min_value=0.0, max_value=1.0),
+            FieldSpec("include_aa", FieldType.BOOL, optional=True, default=False),
+            FieldSpec("max_diff_ratio", FieldType.FLOAT, optional=True,
+                      min_value=0.0, max_value=1.0),
+        ),
+        description="Perceptual image diff that ignores anti-aliased edges.",
+    ))
 
 
 def _add_ocr_specs(specs: List[CommandSpec]) -> None:

--- a/je_auto_control/utils/action_grounding/__init__.py
+++ b/je_auto_control/utils/action_grounding/__init__.py
@@ -1,0 +1,6 @@
+"""Pre-action grounding guard (bounds check + snap-to-element)."""
+from je_auto_control.utils.action_grounding.action_grounding import (
+    in_bounds, snap_to_element, validate_action,
+)
+
+__all__ = ["in_bounds", "snap_to_element", "validate_action"]

--- a/je_auto_control/utils/action_grounding/action_grounding.py
+++ b/je_auto_control/utils/action_grounding/action_grounding.py
@@ -1,0 +1,74 @@
+"""Pre-action grounding guard — reject out-of-bounds clicks, snap near-misses.
+
+``guardrail`` scans text for prompt-injection and ``loop_guard`` detects stuck loops —
+but neither validates a *coordinate action* before it is dispatched. An agent loop
+executes whatever the model returns with no bounds or target check, so a hallucinated
+``(9999, -5)`` click fires into nothing and a 5-pixel-off click misses the button. This
+adds the "detect misaligned actions before execution" guard: reject clicks outside the
+screen and snap a near-miss coordinate onto the nearest known element's centre.
+
+Pure-stdlib geometry over plain element dicts (``x`` / ``y`` / ``width`` / ``height``),
+so it is fully unit-testable. Imports no ``PySide6``.
+"""
+import math
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+Element = Dict[str, Any]
+
+
+def in_bounds(x: int, y: int, screen_size: Sequence[int]) -> bool:
+    """Whether ``(x, y)`` lies within the ``(width, height)`` screen."""
+    width, height = int(screen_size[0]), int(screen_size[1])
+    return 0 <= int(x) < width and 0 <= int(y) < height
+
+
+def _center(element: Element) -> List[int]:
+    return [int(element["x"]) + int(element["width"]) // 2,
+            int(element["y"]) + int(element["height"]) // 2]
+
+
+def _contains(element: Element, x: int, y: int) -> bool:
+    return (int(element["x"]) <= x < int(element["x"]) + int(element["width"])
+            and int(element["y"]) <= y < int(element["y"]) + int(element["height"]))
+
+
+def snap_to_element(x: int, y: int, elements: Sequence[Element], *,
+                    max_dist: float = 8.0) -> Optional[List[int]]:
+    """Return the centre of the element at / nearest to ``(x, y)`` (or ``None``).
+
+    A point inside an element snaps to that element's centre; otherwise the nearest
+    element centre within ``max_dist`` pixels is returned, else ``None``.
+    """
+    px, py = int(x), int(y)
+    for element in elements:
+        if _contains(element, px, py):
+            return _center(element)
+    best: Optional[List[int]] = None
+    best_dist = float("inf")
+    for element in elements:
+        cx, cy = _center(element)
+        dist = math.hypot(cx - px, cy - py)
+        if dist < best_dist:
+            best_dist, best = dist, [cx, cy]
+    return best if best is not None and best_dist <= float(max_dist) else None
+
+
+def validate_action(action: Mapping[str, Any], *, screen_size: Sequence[int],
+                    targets: Optional[Sequence[Element]] = None) -> Dict[str, Any]:
+    """Validate a canonical action before dispatch; optionally snap to a target.
+
+    Returns ``{ok, reason, snapped}``. A coordinate outside ``screen_size`` is
+    rejected (``ok=False``); when ``targets`` are given, a near-miss coordinate is
+    snapped onto the nearest element's centre (``snapped=[x, y]``). Actions without a
+    coordinate always pass.
+    """
+    x, y = action.get("x"), action.get("y")
+    if x is None or y is None:
+        return {"ok": True, "reason": "no coordinate", "snapped": None}
+    if not in_bounds(x, y, screen_size):
+        return {"ok": False, "reason": "out of bounds", "snapped": None}
+    if targets:
+        snapped = snap_to_element(x, y, targets)
+        if snapped is not None:
+            return {"ok": True, "reason": "snapped", "snapped": snapped}
+    return {"ok": True, "reason": "in bounds", "snapped": None}

--- a/je_auto_control/utils/agent_replay/__init__.py
+++ b/je_auto_control/utils/agent_replay/__init__.py
@@ -1,0 +1,6 @@
+"""Portable agent-trajectory trace (record observation->action steps, replay)."""
+from je_auto_control.utils.agent_replay.agent_replay import (
+    from_jsonl, record_step, replay_trace, to_jsonl,
+)
+
+__all__ = ["from_jsonl", "record_step", "replay_trace", "to_jsonl"]

--- a/je_auto_control/utils/agent_replay/agent_replay.py
+++ b/je_auto_control/utils/agent_replay/agent_replay.py
@@ -1,0 +1,57 @@
+"""Portable agent-trajectory trace — record observation→action steps, replay them.
+
+``agent_trace`` records OpenTelemetry GenAI *spans* (tokens / latency / cost) — that is
+observability, not a replayable observation→action transcript; ``trajectory_eval``
+*scores* a trajectory but defines no persisted on-disk format and cannot replay it; and
+``semantic_recording`` replays recorded *human input macros*, not *agent* decisions.
+This is the OmniTool-style "log the trajectory to build a replay / training dataset"
+format: ``{step, observation, action, result}`` JSONL with a deterministic replay
+driver.
+
+Pure-stdlib JSONL; the replay driver takes an injectable ``runner`` (no live model), so
+it is fully unit-testable. Imports no ``PySide6``.
+"""
+import json
+from typing import Any, Callable, Dict, List, Mapping, Sequence
+
+Step = Dict[str, Any]
+
+
+def record_step(trace: List[Step], observation: Any, action: Any,
+                result: Any = None) -> Step:
+    """Append an ``{step, observation, action[, result]}`` entry to ``trace``.
+
+    Mutates and returns the new step; ``step`` is the running index.
+    """
+    step: Step = {"step": len(trace), "observation": observation,
+                  "action": action}
+    if result is not None:
+        step["result"] = result
+    trace.append(step)
+    return step
+
+
+def to_jsonl(trace: Sequence[Mapping[str, Any]]) -> str:
+    """Serialize a trace to newline-delimited JSON (one step per line)."""
+    return "\n".join(json.dumps(step, ensure_ascii=False, sort_keys=True)
+                     for step in trace)
+
+
+def from_jsonl(text: str) -> List[Step]:
+    """Parse a JSONL trace back into a list of step dicts."""
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def replay_trace(trace: Sequence[Mapping[str, Any]],
+                 runner: Callable[[Any], Any]) -> List[Step]:
+    """Replay each step's ``action`` through ``runner``; return the replay results.
+
+    ``runner(action)`` performs the action and returns its result. The output is a list
+    of ``{step, action, result}`` in order — the basis for agent regression testing.
+    """
+    results: List[Step] = []
+    for index, step in enumerate(trace):
+        action = step.get("action")
+        results.append({"step": step.get("step", index), "action": action,
+                        "result": runner(action)})
+    return results

--- a/je_auto_control/utils/barcode/__init__.py
+++ b/je_auto_control/utils/barcode/__init__.py
@@ -1,0 +1,4 @@
+"""1-D barcode decoding (EAN / UPC) with an injectable decoder seam."""
+from je_auto_control.utils.barcode.barcode import read_barcodes
+
+__all__ = ["read_barcodes"]

--- a/je_auto_control/utils/barcode/barcode.py
+++ b/je_auto_control/utils/barcode/barcode.py
@@ -1,0 +1,49 @@
+"""1-D barcode decoding — EAN / UPC, with an injectable decoder seam.
+
+The ``qr`` module decodes QR codes only (``cv2.QRCodeDetector``); there is no 1-D /
+linear barcode (EAN-8/13, UPC-A/E, Code-128) decode. This mirrors ``qr``'s injectable-
+decoder pattern so it is testable without a real barcode and future-proof against
+backend availability: the default decoder uses ``cv2.barcode.BarcodeDetector`` (base
+OpenCV since 4.8) and degrades to an empty result when that module is absent.
+
+Runs on an injectable image (ndarray / path / PIL, default: grab the screen / region),
+so it is headless-testable on synthetic arrays with an injected decoder. OpenCV +
+NumPy come in via ``je_open_cv``. Imports no ``PySide6``.
+"""
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from je_auto_control.utils.visual_match.visual_match import _haystack_gray
+
+ImageSource = Any
+Decoder = Callable[[Any], List[Dict[str, Any]]]
+
+
+def _default_decoder(image) -> List[Dict[str, Any]]:
+    """Decode 1-D barcodes with ``cv2.barcode`` (empty if the module is absent)."""
+    import cv2
+    if not hasattr(cv2, "barcode"):
+        return []
+    retval, infos, types, points = cv2.barcode.BarcodeDetector(
+    ).detectAndDecodeWithType(image)
+    if not retval:
+        return []
+    results: List[Dict[str, Any]] = []
+    for text, kind, corners in zip(infos, types, points):
+        if not text:
+            continue
+        results.append({"text": text, "type": str(kind),
+                        "points": [[int(x), int(y)] for x, y in corners]})
+    return results
+
+
+def read_barcodes(source: Optional[ImageSource] = None, *,
+                  region: Optional[Sequence[int]] = None,
+                  decoder: Optional[Decoder] = None) -> List[Dict[str, Any]]:
+    """Return the 1-D barcodes found in ``source`` (or the screen / ``region``).
+
+    Each result is ``{text, type, points}``. ``decoder`` is injectable (it receives the
+    loaded image and returns the result list); the default uses ``cv2.barcode`` and
+    returns ``[]`` when that backend is unavailable.
+    """
+    image = _haystack_gray(source, region)
+    return (decoder or _default_decoder)(image)

--- a/je_auto_control/utils/clipboard_files/__init__.py
+++ b/je_auto_control/utils/clipboard_files/__init__.py
@@ -1,0 +1,9 @@
+"""Clipboard file-drop list (CF_HDROP): pure DROPFILES packing + Win32 set/get."""
+from je_auto_control.utils.clipboard_files.clipboard_files import (
+    build_dropfiles, get_clipboard_files, parse_dropfiles, set_clipboard_files,
+)
+
+__all__ = [
+    "build_dropfiles", "parse_dropfiles",
+    "set_clipboard_files", "get_clipboard_files",
+]

--- a/je_auto_control/utils/clipboard_files/clipboard_files.py
+++ b/je_auto_control/utils/clipboard_files/clipboard_files.py
@@ -1,0 +1,108 @@
+"""Clipboard file-drop list (Windows ``CF_HDROP`` / ``DROPFILES``).
+
+The clipboard layer carries text and images, and ``rich_clipboard`` added HTML, but the
+framework could never put a *list of files* on the clipboard — the thing Explorer reads
+when you copy files and ``Ctrl+V`` them elsewhere (a ``CF_HDROP`` drop). Building that
+blob is fiddly byte work: a fixed ``DROPFILES`` header followed by a double-null-terminated
+(optionally wide) path list, with the header's ``pFiles`` offset pointing at the list.
+
+This isolates that error-prone packing into pure, fully unit-testable ``build_dropfiles`` /
+``parse_dropfiles`` byte functions (no device needed), with thin Windows-only
+``set_clipboard_files`` / ``get_clipboard_files`` wrappers on top — the same split
+``rich_clipboard`` uses for ``CF_HTML``. The pure functions import no ``PySide6`` and run
+on any platform; only the clipboard wrappers touch Win32.
+"""
+import struct
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+_CF_HDROP = 15
+_GMEM_MOVEABLE = 0x0002
+_HEADER_SIZE = 20  # DROPFILES: pFiles + pt.x + pt.y + fNC + fWide (5 x DWORD)
+
+
+def build_dropfiles(paths: Sequence[str], *, point: Tuple[int, int] = (0, 0),
+                    wide: bool = True, non_client: bool = False) -> bytes:
+    """Pack ``paths`` into a ``CF_HDROP`` / ``DROPFILES`` byte blob.
+
+    ``point`` is the drop coordinate, ``wide`` selects UTF-16LE (the modern default)
+    over single-byte paths, and ``non_client`` sets the ``fNC`` flag. The path list is
+    double-null terminated as the format requires.
+    """
+    if not paths:
+        raise ValueError("at least one path is required")
+    header = struct.pack("<5I", _HEADER_SIZE, int(point[0]), int(point[1]),
+                         1 if non_client else 0, 1 if wide else 0)
+    listing = "".join(f"{path}\0" for path in paths) + "\0"
+    body = listing.encode("utf-16-le" if wide else "latin-1")
+    return header + body
+
+
+def parse_dropfiles(data: bytes) -> Dict[str, Any]:
+    """Unpack a ``CF_HDROP`` / ``DROPFILES`` blob into ``{paths, point, wide, non_client}``."""
+    if len(data) < _HEADER_SIZE:
+        raise ValueError("data too short for a DROPFILES header")
+    p_files, x, y, f_nc, f_wide = struct.unpack("<5I", data[:_HEADER_SIZE])
+    wide = bool(f_wide)
+    body = data[p_files:]
+    text = body.decode("utf-16-le" if wide else "latin-1")
+    paths = [part for part in text.split("\0") if part]
+    return {"paths": paths, "point": [x, y], "wide": wide,
+            "non_client": bool(f_nc)}
+
+
+def set_clipboard_files(paths: Sequence[str], *, point: Tuple[int, int] = (0, 0),
+                        non_client: bool = False) -> None:
+    """Put ``paths`` on the clipboard as a ``CF_HDROP`` file-drop list (Windows)."""
+    blob = build_dropfiles(paths, point=point, wide=True, non_client=non_client)
+    _win_set_hdrop(blob)
+
+
+def get_clipboard_files() -> Optional[List[str]]:
+    """Return the file paths on the clipboard as a ``CF_HDROP`` list, or ``None``."""
+    blob = _win_get_hdrop()
+    if blob is None:
+        return None
+    return parse_dropfiles(blob)["paths"]
+
+
+def _win_set_hdrop(blob: bytes) -> None:
+    import ctypes
+    from ctypes import wintypes
+    user32, kernel32 = ctypes.windll.user32, ctypes.windll.kernel32
+    kernel32.GlobalAlloc.restype = wintypes.HGLOBAL
+    kernel32.GlobalLock.restype = ctypes.c_void_p
+    if not user32.OpenClipboard(None):
+        raise RuntimeError("OpenClipboard failed")
+    try:
+        user32.EmptyClipboard()
+        handle = kernel32.GlobalAlloc(_GMEM_MOVEABLE, len(blob))
+        if not handle:
+            raise RuntimeError("GlobalAlloc failed")
+        pointer = kernel32.GlobalLock(handle)
+        ctypes.memmove(pointer, blob, len(blob))
+        kernel32.GlobalUnlock(handle)
+        if not user32.SetClipboardData(_CF_HDROP, handle):
+            raise RuntimeError("SetClipboardData(CF_HDROP) failed")
+    finally:
+        user32.CloseClipboard()
+
+
+def _win_get_hdrop() -> Optional[bytes]:
+    import ctypes
+    from ctypes import wintypes
+    user32, kernel32 = ctypes.windll.user32, ctypes.windll.kernel32
+    user32.GetClipboardData.restype = wintypes.HANDLE
+    kernel32.GlobalLock.restype = ctypes.c_void_p
+    if not user32.OpenClipboard(None):
+        raise RuntimeError("OpenClipboard failed")
+    try:
+        handle = user32.GetClipboardData(_CF_HDROP)
+        if not handle:
+            return None
+        pointer = kernel32.GlobalLock(handle)
+        size = kernel32.GlobalSize(handle)
+        data = ctypes.string_at(pointer, size)
+        kernel32.GlobalUnlock(handle)
+        return data
+    finally:
+        user32.CloseClipboard()

--- a/je_auto_control/utils/cua_action/__init__.py
+++ b/je_auto_control/utils/cua_action/__init__.py
@@ -1,0 +1,7 @@
+"""Canonical computer-use action schema (normalize Anthropic / OpenAI -> AC_*)."""
+from je_auto_control.utils.cua_action.cua_action import (
+    canonical_action, from_anthropic, from_openai_cua, to_ac_command,
+)
+
+__all__ = ["canonical_action", "from_anthropic", "from_openai_cua",
+           "to_ac_command"]

--- a/je_auto_control/utils/cua_action/cua_action.py
+++ b/je_auto_control/utils/cua_action/cua_action.py
@@ -1,0 +1,120 @@
+"""Canonical computer-use action schema — normalize Anthropic / OpenAI payloads to AC_*.
+
+``tool_use_schema`` exports the AC_* command *signatures* as tool definitions and
+``coordinate_space`` rescales a model grid — but neither *normalizes an inbound action
+payload*. Anthropic emits ``{action:"left_click", coordinate:[x,y]}``, OpenAI's CUA
+emits ``{type:"click", x, y, button}`` — there is no adapter mapping these heterogeneous
+shapes onto a canonical action and then onto a runnable AC_* command. Integrators
+hand-write this glue today.
+
+All pure-stdlib dict mapping (an optional ``scale`` callable applies coordinate-space
+rescaling), so it is fully headless-testable. Imports no ``PySide6``.
+"""
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+from je_auto_control.utils.exception.exceptions import AutoControlActionException
+
+# Anthropic computer-use "action" -> canonical type.
+_ANTHROPIC = {"left_click": "click", "right_click": "right_click",
+              "middle_click": "middle_click", "double_click": "double_click",
+              "mouse_move": "move", "left_click_drag": "drag", "type": "type",
+              "key": "key", "scroll": "scroll", "screenshot": "screenshot",
+              "cursor_position": "cursor_position"}
+
+# canonical click type -> AC mouse button keycode.
+_CLICK_BUTTONS = {"click": "mouse_left", "double_click": "mouse_left",
+                  "right_click": "mouse_right", "middle_click": "mouse_middle"}
+
+
+def canonical_action(action_type: str, **fields: Any) -> Dict[str, Any]:
+    """Build a canonical action dict ``{type, …}`` dropping ``None`` fields."""
+    result: Dict[str, Any] = {"type": action_type}
+    result.update({key: value for key, value in fields.items() if value is not None})
+    return result
+
+
+def _xy(coordinate) -> Dict[str, int]:
+    if not coordinate:
+        return {}
+    return {"x": int(coordinate[0]), "y": int(coordinate[1])}
+
+
+def from_anthropic(tool_input: Mapping[str, Any]) -> Dict[str, Any]:
+    """Normalize an Anthropic computer-use tool input to a canonical action."""
+    action = tool_input.get("action", "")
+    fields: Dict[str, Any] = _xy(tool_input.get("coordinate"))
+    if tool_input.get("text") is not None:
+        fields["text"] = tool_input["text"]
+    if action == "scroll":
+        fields["direction"] = tool_input.get("scroll_direction")
+        fields["amount"] = tool_input.get("scroll_amount")
+    return canonical_action(_ANTHROPIC.get(action, action), **fields)
+
+
+def _openai_click_type(item: Mapping[str, Any]) -> str:
+    button = item.get("button", "left")
+    return {"right": "right_click", "wheel": "middle_click",
+            "middle": "middle_click"}.get(button, "click")
+
+
+def from_openai_cua(item: Mapping[str, Any]) -> Dict[str, Any]:
+    """Normalize an OpenAI CUA ``computer_call`` item to a canonical action."""
+    kind = item.get("type", "")
+    fields: Dict[str, Any] = {}
+    if item.get("x") is not None and item.get("y") is not None:
+        fields["x"], fields["y"] = int(item["x"]), int(item["y"])
+    if kind == "click":
+        kind = _openai_click_type(item)
+    elif kind == "keypress":
+        kind, fields["text"] = "key", "+".join(item.get("keys", []))
+    elif kind == "type":
+        fields["text"] = item.get("text")
+    elif kind == "scroll":
+        fields["scroll_x"] = item.get("scroll_x")
+        fields["scroll_y"] = item.get("scroll_y")
+    return canonical_action(kind, **fields)
+
+
+def _scroll_value(action: Mapping[str, Any]) -> int:
+    if action.get("amount") is not None:
+        sign = 1 if action.get("direction") in ("up", "left") else -1
+        return sign * int(action["amount"])
+    if action.get("scroll_y") is not None:
+        return -int(action["scroll_y"])              # OpenAI: +y is downward
+    return 0
+
+
+def _point(action: Mapping[str, Any],
+           scale: Optional[Callable[[int, int], Any]]) -> Dict[str, int]:
+    if action.get("x") is None or action.get("y") is None:
+        return {}
+    x, y = int(action["x"]), int(action["y"])
+    if scale is not None:
+        x, y = (int(coord) for coord in scale(x, y))
+    return {"x": x, "y": y}
+
+
+def to_ac_command(action: Mapping[str, Any], *,
+                  scale: Optional[Callable[[int, int], Any]] = None) -> List[Any]:
+    """Map a canonical action to a runnable ``[command_name, params]`` AC action.
+
+    ``scale`` optionally remaps ``(x, y)`` (e.g. ``coordinate_space`` model→physical).
+    Raises ``AutoControlActionException`` for an action with no AC mapping.
+    """
+    kind = action.get("type")
+    point = _point(action, scale)
+    if kind in _CLICK_BUTTONS:
+        return ["AC_click_mouse", {"mouse_keycode": _CLICK_BUTTONS[kind], **point}]
+    keys = [part.strip() for part in str(action.get("text", "")).split("+")
+            if part.strip()]
+    builders = {
+        "move": lambda: ["AC_set_mouse_position", point],
+        "type": lambda: ["AC_write", {"write_string": str(action.get("text", ""))}],
+        "key": lambda: ["AC_hotkey", {"key_code_list": keys}],
+        "scroll": lambda: ["AC_mouse_scroll",
+                           {"scroll_value": _scroll_value(action), **point}],
+        "screenshot": lambda: ["AC_screenshot", {}],
+    }
+    if kind in builders:
+        return builders[kind]()
+    raise AutoControlActionException(f"no AC mapping for action type: {kind!r}")

--- a/je_auto_control/utils/element_diff/__init__.py
+++ b/je_auto_control/utils/element_diff/__init__.py
@@ -1,0 +1,6 @@
+"""Geometry-aware element matching across frames (stable IDs, move tracking)."""
+from je_auto_control.utils.element_diff.element_diff import (
+    assign_stable_ids, match_elements,
+)
+
+__all__ = ["assign_stable_ids", "match_elements"]

--- a/je_auto_control/utils/element_diff/element_diff.py
+++ b/je_auto_control/utils/element_diff/element_diff.py
@@ -1,0 +1,82 @@
+"""Geometry-aware element matching across frames — stable IDs, move tracking.
+
+``screen_state.diff_snapshots`` keys element identity strictly on ``(role, name)`` — so
+it cannot match an element whose label changed but position is stable, cannot track a
+renamed control, and cannot produce persistent IDs across frames. Geometry-aware
+matching (intersection-over-union, reusing :doc:`v138_features_doc`'s ``iou``) is the
+basis for stable element IDs an agent can refer to turn-over-turn: a button that moved
+3px keeps its id, a renamed-but-stationary control matches by overlap, a genuinely new
+element gets a fresh id.
+
+Pure-stdlib over plain element dicts (``x`` / ``y`` / ``width`` / ``height``), so it is
+fully unit-testable. Imports no ``PySide6``.
+"""
+from typing import Any, Dict, List, Optional, Sequence
+
+from je_auto_control.utils.element_parse import iou
+
+Element = Dict[str, Any]
+
+
+def match_elements(before: Sequence[Element], after: Sequence[Element], *,
+                   iou_threshold: float = 0.5) -> Dict[str, Any]:
+    """Greedily match ``before`` elements to ``after`` by overlap.
+
+    Returns ``{matched: [{before, after, iou}], added: [...], removed: [...]}`` — a
+    ``before`` element with no overlap above ``iou_threshold`` is *removed*, an
+    unmatched ``after`` element is *added*.
+    """
+    after = list(after)
+    taken: set = set()
+    matched: List[Dict[str, Any]] = []
+    removed: List[Element] = []
+    for element in before:
+        best_index, best_score = -1, float(iou_threshold)
+        for index, candidate in enumerate(after):
+            if index in taken:
+                continue
+            score = iou(element, candidate)
+            if score >= best_score:
+                best_index, best_score = index, score
+        if best_index >= 0:
+            taken.add(best_index)
+            matched.append({"before": element, "after": after[best_index],
+                            "iou": round(best_score, 4)})
+        else:
+            removed.append(element)
+    added = [candidate for index, candidate in enumerate(after)
+             if index not in taken]
+    return {"matched": matched, "added": added, "removed": removed}
+
+
+def _best_prior(element: Element, prior: Sequence[Element],
+                iou_threshold: float) -> Optional[Element]:
+    best, best_score = None, float(iou_threshold)
+    for candidate in prior:
+        score = iou(element, candidate)
+        if score >= best_score:
+            best, best_score = candidate, score
+    return best
+
+
+def assign_stable_ids(elements: Sequence[Element],
+                      prior: Optional[Sequence[Element]] = None, *,
+                      iou_threshold: float = 0.5) -> List[Element]:
+    """Return ``elements`` each tagged with a stable ``id``, carried from ``prior``.
+
+    With no ``prior`` every element gets a fresh sequential id; otherwise each element
+    inherits the id of the ``prior`` element it most overlaps (above ``iou_threshold``),
+    and unmatched elements get new ids beyond the highest prior id.
+    """
+    if not prior:
+        return [dict(element, id=index) for index, element in enumerate(elements)]
+    next_id = max((int(p.get("id", -1)) for p in prior), default=-1) + 1
+    result: List[Element] = []
+    for element in elements:
+        match = _best_prior(element, prior, float(iou_threshold))
+        if match is not None and "id" in match:
+            result.append(dict(element, id=int(match["id"])))
+        else:
+            result.append(dict(element, id=next_id))
+            next_id += 1
+    return result

--- a/je_auto_control/utils/element_scoring/__init__.py
+++ b/je_auto_control/utils/element_scoring/__init__.py
@@ -1,0 +1,6 @@
+"""Weighted candidate scoring (role + name similarity + proximity + enabled)."""
+from je_auto_control.utils.element_scoring.element_scoring import (
+    ScoredCandidate, best_candidate, score_candidates,
+)
+
+__all__ = ["ScoredCandidate", "best_candidate", "score_candidates"]

--- a/je_auto_control/utils/element_scoring/element_scoring.py
+++ b/je_auto_control/utils/element_scoring/element_scoring.py
@@ -1,0 +1,88 @@
+"""Weighted candidate scoring — rank ambiguous elements by role + name + proximity.
+
+``anchor_locator`` filters by a single spatial relation and sorts by distance, and
+``ab_locator`` races *whole strategies* and picks by elapsed time — neither is a
+*weighted multi-signal scorer* that ranks ambiguous candidates by combining a role
+match, a fuzzy name similarity, proximity to an anchor and enabled-state into one
+confidence. That is what self-healing / grounding needs when several boxes could be the
+target. The name similarity is injectable (defaulting to the project's ``fuzzy_ratio``),
+so no new string-distance code is added.
+
+Pure-stdlib over plain element dicts (``role`` / ``name`` / ``x`` / ``y`` / ``width`` /
+``height`` / optional ``enabled``), fully unit-testable. Imports no ``PySide6``.
+"""
+import math
+from dataclasses import asdict, dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from je_auto_control.utils.fuzzy import fuzzy_ratio
+
+Element = Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ScoredCandidate:
+    """One ranked candidate: the element, its 0..1 ``score`` and the per-signal breakdown."""
+
+    element: Element
+    score: float
+    matched_on: Dict[str, float]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the scored candidate as a plain dict."""
+        return asdict(self)
+
+
+def _proximity(element: Element, anchor: Sequence[int]) -> float:
+    cx = int(element.get("x", 0)) + int(element.get("width", 0)) // 2
+    cy = int(element.get("y", 0)) + int(element.get("height", 0)) // 2
+    distance = math.hypot(cx - int(anchor[0]), cy - int(anchor[1]))
+    return 1.0 / (1.0 + distance / 100.0)
+
+
+def score_candidates(candidates: Sequence[Element], *,
+                     want_role: Optional[str] = None,
+                     want_name: Optional[str] = None,
+                     name_similarity: Optional[Callable[[str, str], float]] = None,
+                     prefer_enabled: bool = True,
+                     anchor: Optional[Sequence[int]] = None
+                     ) -> List[ScoredCandidate]:
+    """Score and rank ``candidates`` best-first by the supplied signals.
+
+    Each active signal contributes 0..1 and the score is their mean: ``want_role`` (1
+    on an exact role match), ``want_name`` (via ``name_similarity``, default
+    ``fuzzy_ratio``), ``anchor`` proximity, and ``prefer_enabled``. ``matched_on`` holds
+    the per-signal breakdown.
+    """
+    similarity = name_similarity or fuzzy_ratio
+    scored: List[ScoredCandidate] = []
+    for element in candidates:
+        parts: Dict[str, float] = {}
+        if want_role is not None:
+            parts["role"] = (1.0 if str(element.get("role", "")).lower()
+                             == str(want_role).lower() else 0.0)
+        if want_name is not None:
+            parts["name"] = float(similarity(want_name,
+                                             str(element.get("name", ""))))
+        if anchor is not None:
+            parts["proximity"] = _proximity(element, anchor)
+        if prefer_enabled:
+            parts["enabled"] = 1.0 if element.get("enabled", True) else 0.0
+        score = sum(parts.values()) / len(parts) if parts else 0.0
+        scored.append(ScoredCandidate(element, round(score, 4), parts))
+    scored.sort(key=lambda candidate: candidate.score, reverse=True)
+    return scored
+
+
+def best_candidate(candidates: Sequence[Element], *,
+                   want_role: Optional[str] = None,
+                   want_name: Optional[str] = None,
+                   name_similarity: Optional[Callable[[str, str], float]] = None,
+                   prefer_enabled: bool = True,
+                   anchor: Optional[Sequence[int]] = None
+                   ) -> Optional[ScoredCandidate]:
+    """Return the single highest-scoring candidate (or ``None`` if there are none)."""
+    scored = score_candidates(candidates, want_role=want_role, want_name=want_name,
+                              name_similarity=name_similarity,
+                              prefer_enabled=prefer_enabled, anchor=anchor)
+    return scored[0] if scored else None

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3707,6 +3707,34 @@ def _histogram_changed(reference: str, current: Any = None, method: str =
             "score": compare_histograms(ref_hist, cur_hist, method=str(method))}
 
 
+def _changed_regions(before: str, after: Any = None, threshold: Any = 25,
+                     min_area: Any = 80, blur: Any = 5) -> Dict[str, Any]:
+    """Adapter: boxes of regions that moved between two frames (after=screen)."""
+    from je_auto_control.utils.motion_regions import changed_regions
+    regions = changed_regions(before, _resolve_after(after), threshold=int(threshold),
+                              min_area=int(min_area), blur=int(blur))
+    return {"count": len(regions), "regions": regions}
+
+
+def _has_motion(before: str, after: Any = None, threshold: Any = 25,
+                min_area: Any = 80) -> Dict[str, Any]:
+    """Adapter: whether anything moved between two frames (after=screen)."""
+    from je_auto_control.utils.motion_regions import activity_score, has_motion
+    resolved = _resolve_after(after)
+    return {"moved": has_motion(before, resolved, threshold=int(threshold),
+                                min_area=int(min_area)),
+            "activity": activity_score(before, resolved, threshold=int(threshold))}
+
+
+def _resolve_after(after: Any):
+    """Return the 'after' frame, grabbing the screen when it is not given."""
+    if after is not None:
+        return after
+    import numpy as np
+    from je_auto_control.utils.cv2_utils.screenshot import pil_screenshot
+    return np.asarray(pil_screenshot().convert("RGB"))
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5452,6 +5480,8 @@ class Executor:
             "AC_get_clipboard_html": _get_clipboard_html,
             "AC_image_histogram": _image_histogram,
             "AC_histogram_changed": _histogram_changed,
+            "AC_changed_regions": _changed_regions,
+            "AC_has_motion": _has_motion,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3784,6 +3784,20 @@ def _soft_assert(checks: Any, raise_on_fail: Any = False) -> Dict[str, Any]:
             "failures": soft.failures}
 
 
+def _perceptual_diff(actual: str, expected: str, threshold: Any = 0.1,
+                     include_aa: Any = False,
+                     max_diff_ratio: Any = None) -> Dict[str, Any]:
+    """Adapter: perceptual (YIQ) image diff with anti-alias suppression."""
+    from je_auto_control.utils.perceptual_diff import perceptual_diff
+    result = perceptual_diff(actual, expected, threshold=float(threshold),
+                             include_aa=bool(include_aa))
+    if max_diff_ratio is not None and result.diff_ratio > float(max_diff_ratio):
+        raise AutoControlActionException(
+            f"perceptual diff {result.diff_ratio} exceeds {max_diff_ratio}")
+    return {"diff_pixels": result.diff_pixels, "total_pixels": result.total_pixels,
+            "diff_ratio": result.diff_ratio, "regions": result.regions}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5535,6 +5549,7 @@ class Executor:
             "AC_bring_to_front": _bring_to_front,
             "AC_send_to_back": _send_to_back,
             "AC_soft_assert": _soft_assert,
+            "AC_perceptual_diff": _perceptual_diff,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3323,6 +3323,40 @@ def _match_rotated_all(template: str, min_score: Any = 0.8, scales: Any = None,
     return {"count": len(matches), "matches": [m.to_dict() for m in matches]}
 
 
+def _region_arg(value: Any) -> Optional[List[int]]:
+    """Coerce a JSON-string / list region arg into a list of ints, or None."""
+    import json
+    if isinstance(value, str):
+        value = json.loads(value) if value.strip() else None
+    return [int(v) for v in value] if value else None
+
+
+def _grid_cells(rows: Any, cols: Any, region: Any = None) -> Dict[str, Any]:
+    """Adapter: every cell of an rows x cols labelled grid over the screen."""
+    from je_auto_control.utils.screen_grid import grid_cells
+    cells = grid_cells(int(rows), int(cols), region=_region_arg(region))
+    return {"count": len(cells), "cells": [c.to_dict() for c in cells]}
+
+
+def _cell_for_point(x: Any, y: Any, rows: Any, cols: Any,
+                    region: Any = None) -> Dict[str, Any]:
+    """Adapter: the grid cell containing a point (or found=False if outside)."""
+    from je_auto_control.utils.screen_grid import cell_for_point
+    cell = cell_for_point(int(x), int(y), int(rows), int(cols),
+                          region=_region_arg(region))
+    return {"found": cell is not None,
+            "cell": cell.to_dict() if cell else None}
+
+
+def _point_for_cell(label: str, rows: Any, cols: Any,
+                    region: Any = None) -> Dict[str, Any]:
+    """Adapter: the centre point of a named grid cell (ready to click)."""
+    from je_auto_control.utils.screen_grid import point_for_cell
+    point = point_for_cell(str(label), int(rows), int(cols),
+                           region=_region_arg(region))
+    return {"point": point}
+
+
 def _find_color_region(rgb: Any, tolerance: Any = 20, min_area: Any = 50,
                        region: Any = None) -> Dict[str, Any]:
     """Adapter: locate coloured regions on the screen, largest first."""
@@ -5727,6 +5761,9 @@ class Executor:
             "AC_match_masked_all": _match_masked_all,
             "AC_match_rotated": _match_rotated,
             "AC_match_rotated_all": _match_rotated_all,
+            "AC_grid_cells": _grid_cells,
+            "AC_cell_for_point": _cell_for_point,
+            "AC_point_for_cell": _point_for_cell,
             "AC_ssim_compare": _ssim_compare,
             "AC_ssim_changed_regions": _ssim_changed_regions,
             "AC_feature_match": _feature_match,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3894,6 +3894,36 @@ def _replay_trace(trace: Any) -> Dict[str, Any]:
     return {"count": len(results), "results": results}
 
 
+def _match_elements(before: Any, after: Any,
+                    iou_threshold: Any = 0.5) -> Dict[str, Any]:
+    """Adapter: geometry-aware match of two element-box lists."""
+    import json
+    from je_auto_control.utils.element_diff import match_elements
+    if isinstance(before, str):
+        before = json.loads(before)
+    if isinstance(after, str):
+        after = json.loads(after)
+    result = match_elements(list(before), list(after),
+                            iou_threshold=float(iou_threshold))
+    return {"matched": result["matched"], "added": result["added"],
+            "removed": result["removed"]}
+
+
+def _assign_stable_ids(elements: Any, prior: Any = None,
+                       iou_threshold: Any = 0.5) -> Dict[str, Any]:
+    """Adapter: tag element boxes with stable IDs carried from a prior frame."""
+    import json
+    from je_auto_control.utils.element_diff import assign_stable_ids
+    if isinstance(elements, str):
+        elements = json.loads(elements)
+    if isinstance(prior, str):
+        prior = json.loads(prior) if prior.strip() else None
+    tagged = assign_stable_ids(list(elements),
+                               prior=list(prior) if prior else None,
+                               iou_threshold=float(iou_threshold))
+    return {"count": len(tagged), "elements": tagged}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5653,6 +5683,8 @@ class Executor:
             "AC_observation_index": _observation_index,
             "AC_validate_action": _validate_action,
             "AC_replay_trace": _replay_trace,
+            "AC_match_elements": _match_elements,
+            "AC_assign_stable_ids": _assign_stable_ids,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3829,6 +3829,37 @@ def _cua_command(payload: Any, source: str = "canonical") -> Dict[str, Any]:
     return {"canonical": canonical, "command": to_ac_command(canonical)}
 
 
+def _serialize_observation(elements: Any, viewport: Any = None,
+                           max_elements: Any = 80) -> Dict[str, Any]:
+    """Adapter: render an indexed a11y text observation from element dicts."""
+    import json
+    from je_auto_control.utils.observation import (observation_index,
+                                                   serialize_observation)
+    if isinstance(elements, str):
+        elements = json.loads(elements)
+    if isinstance(viewport, str):
+        viewport = json.loads(viewport) if viewport.strip() else None
+    text = serialize_observation(list(elements), viewport=viewport,
+                                 max_elements=int(max_elements))
+    indexed = observation_index(list(elements), viewport=viewport,
+                                max_elements=int(max_elements))
+    return {"observation": text, "count": len(indexed)}
+
+
+def _observation_index(elements: Any, viewport: Any = None,
+                       max_elements: Any = 80) -> Dict[str, Any]:
+    """Adapter: the on-screen elements in reading order, capped, each indexed."""
+    import json
+    from je_auto_control.utils.observation import observation_index
+    if isinstance(elements, str):
+        elements = json.loads(elements)
+    if isinstance(viewport, str):
+        viewport = json.loads(viewport) if viewport.strip() else None
+    indexed = observation_index(list(elements), viewport=viewport,
+                                max_elements=int(max_elements))
+    return {"count": len(indexed), "elements": indexed}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5584,6 +5615,8 @@ class Executor:
             "AC_get_client_rect": _get_client_rect,
             "AC_client_point": _client_point,
             "AC_cua_command": _cua_command,
+            "AC_serialize_observation": _serialize_observation,
+            "AC_observation_index": _observation_index,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3676,6 +3676,37 @@ def _get_clipboard_html() -> Dict[str, Any]:
     return {"found": html is not None, "html": html}
 
 
+def _image_histogram(source: Any = None, bins: Any = 32, space: str = "hsv",
+                     region: Any = None) -> Dict[str, Any]:
+    """Adapter: per-channel colour histogram of an image / the screen."""
+    import json
+    from je_auto_control.utils.img_histogram import image_histogram
+    if isinstance(region, str):
+        region = json.loads(region) if region.strip() else None
+    hist = image_histogram(source, region=region, bins=int(bins), space=str(space))
+    return {"bins": int(bins), "space": str(space), "histogram": hist}
+
+
+def _histogram_changed(reference: str, current: Any = None, method: str =
+                       "correlation", threshold: Any = 0.9, space: str = "hsv",
+                       region: Any = None) -> Dict[str, Any]:
+    """Adapter: whether the screen / current image differs from a reference."""
+    import json
+    from je_auto_control.utils.img_histogram import (compare_histograms,
+                                                     histogram_changed,
+                                                     image_histogram)
+    if isinstance(region, str):
+        region = json.loads(region) if region.strip() else None
+    changed = histogram_changed(reference, current, region=region,
+                                method=str(method), threshold=float(threshold),
+                                space=str(space))
+    ref_hist = image_histogram(reference, space=str(space))
+    cur_hist = (image_histogram(current, space=str(space)) if current is not None
+                else image_histogram(region=region, space=str(space)))
+    return {"changed": changed,
+            "score": compare_histograms(ref_hist, cur_hist, method=str(method))}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5419,6 +5450,8 @@ class Executor:
             "AC_locate_chain": _locate_chain,
             "AC_set_clipboard_html": _set_clipboard_html,
             "AC_get_clipboard_html": _get_clipboard_html,
+            "AC_image_histogram": _image_histogram,
+            "AC_histogram_changed": _histogram_changed,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3878,6 +3878,22 @@ def _validate_action(action: Any, screen: Any = None,
                            targets=list(targets) if targets else None)
 
 
+def _replay_trace(trace: Any) -> Dict[str, Any]:
+    """Adapter: replay a trajectory by running each step's action via the executor."""
+    import json
+    from je_auto_control.utils.agent_replay import from_jsonl, replay_trace
+    if isinstance(trace, str):
+        trace = (json.loads(trace) if trace.strip().startswith("[")
+                 else from_jsonl(trace))
+
+    def runner(action):
+        record = executor.execute_action([list(action)])
+        return next(iter(record.values()), None)
+
+    results = replay_trace(list(trace), runner)
+    return {"count": len(results), "results": results}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5636,6 +5652,7 @@ class Executor:
             "AC_serialize_observation": _serialize_observation,
             "AC_observation_index": _observation_index,
             "AC_validate_action": _validate_action,
+            "AC_replay_trace": _replay_trace,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3798,6 +3798,22 @@ def _perceptual_diff(actual: str, expected: str, threshold: Any = 0.1,
             "diff_ratio": result.diff_ratio, "regions": result.regions}
 
 
+def _get_client_rect(title: str) -> Dict[str, Any]:
+    """Adapter: a window's client-area rect in screen coordinates."""
+    from je_auto_control.utils.window_geometry import get_client_rect
+    rect = get_client_rect(title)
+    return {"found": rect is not None,
+            "rect": list(rect) if rect is not None else None}
+
+
+def _client_point(title: str, x: Any, y: Any) -> Dict[str, Any]:
+    """Adapter: screen point for a client-area-local (x, y) inside a window."""
+    from je_auto_control.utils.window_geometry import client_point
+    point = client_point(title, int(x), int(y))
+    return {"found": point is not None,
+            "point": list(point) if point is not None else None}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5550,6 +5566,8 @@ class Executor:
             "AC_send_to_back": _send_to_back,
             "AC_soft_assert": _soft_assert,
             "AC_perceptual_diff": _perceptual_diff,
+            "AC_get_client_rect": _get_client_rect,
+            "AC_client_point": _client_point,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3924,6 +3924,35 @@ def _assign_stable_ids(elements: Any, prior: Any = None,
     return {"count": len(tagged), "elements": tagged}
 
 
+def _score_candidates(candidates: Any, want_role: Any = None, want_name: Any = None,
+                      anchor: Any = None) -> Dict[str, Any]:
+    """Adapter: rank candidate element boxes by role / name / proximity."""
+    import json
+    from je_auto_control.utils.element_scoring import score_candidates
+    if isinstance(candidates, str):
+        candidates = json.loads(candidates)
+    if isinstance(anchor, str):
+        anchor = json.loads(anchor) if anchor.strip() else None
+    ranked = score_candidates(list(candidates), want_role=want_role,
+                              want_name=want_name, anchor=anchor)
+    return {"count": len(ranked), "scored": [c.to_dict() for c in ranked]}
+
+
+def _best_candidate(candidates: Any, want_role: Any = None, want_name: Any = None,
+                    anchor: Any = None) -> Dict[str, Any]:
+    """Adapter: the single highest-scoring candidate element."""
+    import json
+    from je_auto_control.utils.element_scoring import best_candidate
+    if isinstance(candidates, str):
+        candidates = json.loads(candidates)
+    if isinstance(anchor, str):
+        anchor = json.loads(anchor) if anchor.strip() else None
+    best = best_candidate(list(candidates), want_role=want_role,
+                          want_name=want_name, anchor=anchor)
+    return {"found": best is not None,
+            "best": best.to_dict() if best is not None else None}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5685,6 +5714,8 @@ class Executor:
             "AC_replay_trace": _replay_trace,
             "AC_match_elements": _match_elements,
             "AC_assign_stable_ids": _assign_stable_ids,
+            "AC_score_candidates": _score_candidates,
+            "AC_best_candidate": _best_candidate,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -1,5 +1,5 @@
 import types
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from je_auto_control.utils.exception.exception_tags import (
     action_is_null_error_message, add_command_exception_error_message,
@@ -3282,6 +3282,47 @@ def _match_masked_all(template: str, mask: Any = None, min_score: Any = 0.9,
     return {"count": len(matches), "matches": [m.to_dict() for m in matches]}
 
 
+def _seq_arg(value: Any, default: Sequence[float]) -> Sequence[float]:
+    """Coerce a JSON-string / list arg into a tuple of floats, or the default."""
+    import json
+    if isinstance(value, str):
+        value = json.loads(value) if value.strip() else None
+    return tuple(float(v) for v in value) if value else tuple(default)
+
+
+def _match_rotated(template: str, min_score: Any = 0.8, scales: Any = None,
+                   angles: Any = None, region: Any = None,
+                   method: str = "ccoeff_normed") -> Dict[str, Any]:
+    """Adapter: best rotation/scale-tolerant template match on the screen."""
+    import json
+    from je_auto_control.utils.rotated_match import match_rotated
+    if isinstance(region, str):
+        region = json.loads(region) if region.strip() else None
+    match = match_rotated(template, region=region,
+                          scales=_seq_arg(scales, (1.0,)),
+                          angles=_seq_arg(angles, (0.0,)),
+                          min_score=float(min_score), method=method)
+    return {"found": match is not None,
+            "match": match.to_dict() if match else None}
+
+
+def _match_rotated_all(template: str, min_score: Any = 0.8, scales: Any = None,
+                       angles: Any = None, max_results: Any = 20,
+                       nms_iou: Any = 0.3, region: Any = None) -> Dict[str, Any]:
+    """Adapter: every rotation/scale-tolerant template match (NMS)."""
+    import json
+    from je_auto_control.utils.rotated_match import match_rotated_all
+    if isinstance(region, str):
+        region = json.loads(region) if region.strip() else None
+    matches = match_rotated_all(template, region=region,
+                                scales=_seq_arg(scales, (1.0,)),
+                                angles=_seq_arg(angles, (0.0,)),
+                                min_score=float(min_score),
+                                max_results=int(max_results),
+                                nms_iou=float(nms_iou))
+    return {"count": len(matches), "matches": [m.to_dict() for m in matches]}
+
+
 def _find_color_region(rgb: Any, tolerance: Any = 20, min_area: Any = 50,
                        region: Any = None) -> Dict[str, Any]:
     """Adapter: locate coloured regions on the screen, largest first."""
@@ -5684,6 +5725,8 @@ class Executor:
             "AC_match_template_all": _match_template_all,
             "AC_match_masked": _match_masked,
             "AC_match_masked_all": _match_masked_all,
+            "AC_match_rotated": _match_rotated,
+            "AC_match_rotated_all": _match_rotated_all,
             "AC_ssim_compare": _ssim_compare,
             "AC_ssim_changed_regions": _ssim_changed_regions,
             "AC_feature_match": _feature_match,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3814,6 +3814,21 @@ def _client_point(title: str, x: Any, y: Any) -> Dict[str, Any]:
             "point": list(point) if point is not None else None}
 
 
+def _cua_command(payload: Any, source: str = "canonical") -> Dict[str, Any]:
+    """Adapter: normalize a computer-use payload and map it to an AC_* command."""
+    import json
+    from je_auto_control.utils.cua_action import (from_anthropic, from_openai_cua,
+                                                  to_ac_command)
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    normalizers = {"anthropic": from_anthropic, "openai": from_openai_cua,
+                   "canonical": dict}
+    if source not in normalizers:
+        raise AutoControlActionException(f"unknown cua source: {source!r}")
+    canonical = normalizers[source](payload)
+    return {"canonical": canonical, "command": to_ac_command(canonical)}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5568,6 +5583,7 @@ class Executor:
             "AC_perceptual_diff": _perceptual_diff,
             "AC_get_client_rect": _get_client_rect,
             "AC_client_point": _client_point,
+            "AC_cua_command": _cua_command,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3753,6 +3753,37 @@ def _send_to_back(title: str) -> Dict[str, Any]:
     return {"applied": send_to_back(title)}
 
 
+def _eval_check(op: str, value: Any, expected: Any) -> bool:
+    """Evaluate one soft-assert check by operator name."""
+    table = {"eq": lambda: value == expected,
+             "ne": lambda: value != expected,
+             "gt": lambda: value > expected,
+             "lt": lambda: value < expected,
+             "contains": lambda: expected in value,
+             "truthy": lambda: bool(value)}
+    if op not in table:
+        raise AutoControlActionException(f"unknown soft-assert op: {op!r}")
+    return bool(table[op]())
+
+
+def _soft_assert(checks: Any, raise_on_fail: Any = False) -> Dict[str, Any]:
+    """Adapter: aggregate a list of {value, op, expected, message} checks."""
+    import json
+    from je_auto_control.utils.soft_assert import SoftAssertions
+    if isinstance(checks, str):
+        checks = json.loads(checks)
+    soft = SoftAssertions(raise_on_exit=False)
+    for check in checks or ():
+        op = str(check.get("op", "truthy"))
+        ok = _eval_check(op, check.get("value"), check.get("expected"))
+        soft.check(ok, check.get("message", "")
+                   or f"{check.get('value')!r} {op} {check.get('expected')!r}")
+    if raise_on_fail:
+        soft.assert_all()
+    return {"ok": not soft.failures, "passed": soft.passed,
+            "failures": soft.failures}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5503,6 +5534,7 @@ class Executor:
             "AC_set_topmost": _set_topmost,
             "AC_bring_to_front": _bring_to_front,
             "AC_send_to_back": _send_to_back,
+            "AC_soft_assert": _soft_assert,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3751,6 +3751,24 @@ def _get_clipboard_html() -> Dict[str, Any]:
     return {"found": html is not None, "html": html}
 
 
+def _set_clipboard_files(paths: Any) -> Dict[str, Any]:
+    """Adapter: put a file-drop list (CF_HDROP) on the clipboard (Windows)."""
+    import json
+    from je_auto_control.utils.clipboard_files import set_clipboard_files
+    if isinstance(paths, str):
+        paths = json.loads(paths) if paths.strip().startswith("[") else [paths]
+    paths = [str(p) for p in paths]
+    set_clipboard_files(paths)
+    return {"set": True, "count": len(paths)}
+
+
+def _get_clipboard_files() -> Dict[str, Any]:
+    """Adapter: read the clipboard's file-drop list (CF_HDROP) (Windows)."""
+    from je_auto_control.utils.clipboard_files import get_clipboard_files
+    paths = get_clipboard_files()
+    return {"found": paths is not None, "paths": paths or []}
+
+
 def _image_histogram(source: Any = None, bins: Any = 32, space: str = "hsv",
                      region: Any = None) -> Dict[str, Any]:
     """Adapter: per-channel colour histogram of an image / the screen."""
@@ -5786,6 +5804,8 @@ class Executor:
             "AC_locate_chain": _locate_chain,
             "AC_set_clipboard_html": _set_clipboard_html,
             "AC_get_clipboard_html": _get_clipboard_html,
+            "AC_set_clipboard_files": _set_clipboard_files,
+            "AC_get_clipboard_files": _get_clipboard_files,
             "AC_image_histogram": _image_histogram,
             "AC_histogram_changed": _histogram_changed,
             "AC_changed_regions": _changed_regions,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3860,6 +3860,24 @@ def _observation_index(elements: Any, viewport: Any = None,
     return {"count": len(indexed), "elements": indexed}
 
 
+def _validate_action(action: Any, screen: Any = None,
+                     targets: Any = None) -> Dict[str, Any]:
+    """Adapter: validate a coordinate action (bounds + optional snap-to-target)."""
+    import json
+    from je_auto_control.utils.action_grounding import validate_action
+    if isinstance(action, str):
+        action = json.loads(action)
+    if isinstance(targets, str):
+        targets = json.loads(targets) if targets.strip() else None
+    if isinstance(screen, str):
+        screen = json.loads(screen) if screen.strip() else None
+    if not screen:
+        from je_auto_control.wrapper.auto_control_screen import screen_size
+        screen = list(screen_size())
+    return validate_action(action, screen_size=screen,
+                           targets=list(targets) if targets else None)
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5617,6 +5635,7 @@ class Executor:
             "AC_cua_command": _cua_command,
             "AC_serialize_observation": _serialize_observation,
             "AC_observation_index": _observation_index,
+            "AC_validate_action": _validate_action,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3735,6 +3735,24 @@ def _resolve_after(after: Any):
     return np.asarray(pil_screenshot().convert("RGB"))
 
 
+def _set_topmost(title: str, on: Any = True) -> Dict[str, Any]:
+    """Adapter: pin a window always-on-top (or release it)."""
+    from je_auto_control.utils.window_zorder import set_topmost
+    return {"applied": set_topmost(title, bool(on))}
+
+
+def _bring_to_front(title: str) -> Dict[str, Any]:
+    """Adapter: raise a window to the top of the z-order."""
+    from je_auto_control.utils.window_zorder import bring_to_front
+    return {"applied": bring_to_front(title)}
+
+
+def _send_to_back(title: str) -> Dict[str, Any]:
+    """Adapter: send a window to the bottom of the z-order."""
+    from je_auto_control.utils.window_zorder import send_to_back
+    return {"applied": send_to_back(title)}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5482,6 +5500,9 @@ class Executor:
             "AC_histogram_changed": _histogram_changed,
             "AC_changed_regions": _changed_regions,
             "AC_has_motion": _has_motion,
+            "AC_set_topmost": _set_topmost,
+            "AC_bring_to_front": _bring_to_front,
+            "AC_send_to_back": _send_to_back,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/executor/action_executor.py
+++ b/je_auto_control/utils/executor/action_executor.py
@@ -3953,6 +3953,16 @@ def _best_candidate(candidates: Any, want_role: Any = None, want_name: Any = Non
             "best": best.to_dict() if best is not None else None}
 
 
+def _read_barcodes(source: Any = None, region: Any = None) -> Dict[str, Any]:
+    """Adapter: decode 1-D barcodes on screen / in an image."""
+    import json
+    from je_auto_control.utils.barcode import read_barcodes
+    if isinstance(region, str):
+        region = json.loads(region) if region.strip() else None
+    barcodes = read_barcodes(source, region=region)
+    return {"count": len(barcodes), "barcodes": barcodes}
+
+
 def _with_modifiers(modifiers: Any, actions: Any) -> Dict[str, Any]:
     """Adapter: run nested actions while modifier keys are held down."""
     import json
@@ -5716,6 +5726,7 @@ class Executor:
             "AC_assign_stable_ids": _assign_stable_ids,
             "AC_score_candidates": _score_candidates,
             "AC_best_candidate": _best_candidate,
+            "AC_read_barcodes": _read_barcodes,
             "AC_tile_rect": _tile_rect,
             "AC_grid_rects": _grid_rects,
             "AC_cascade_rects": _cascade_rects,

--- a/je_auto_control/utils/img_histogram/__init__.py
+++ b/je_auto_control/utils/img_histogram/__init__.py
@@ -1,0 +1,6 @@
+"""Colour-histogram fingerprint & change detection (illumination-robust)."""
+from je_auto_control.utils.img_histogram.img_histogram import (
+    compare_histograms, histogram_changed, image_histogram,
+)
+
+__all__ = ["compare_histograms", "histogram_changed", "image_histogram"]

--- a/je_auto_control/utils/img_histogram/img_histogram.py
+++ b/je_auto_control/utils/img_histogram/img_histogram.py
@@ -1,0 +1,93 @@
+"""Colour-histogram fingerprint & change detection — "is this the same view?".
+
+``image_dedup`` fingerprints with a perceptual aHash/dHash (a *spatial* 64-bit hash,
+brittle to colour / theme shifts) and ``color_stats`` reports a single average /
+dominant colour. A normalized colour *histogram* is the standard illumination- and
+scale-robust signal for "is this the same view, or has the palette shifted" — a theme
+switch, a content reload, a rotated ad — which neither hashing nor one dominant colour
+captures.
+
+Every function runs on an injectable image (ndarray / path / PIL, RGB) so it is
+headless-testable on synthetic arrays. ``cv2.calcHist`` / ``cv2.compareHist`` are base
+OpenCV; OpenCV + NumPy come in via ``je_open_cv``. Imports no ``PySide6``.
+"""
+from typing import Any, List, Optional, Sequence
+
+# Reuse the RGB loader / screen grab (single source of truth, no copy).
+from je_auto_control.utils.color_region.color_region import _grab_rgb, _to_rgb
+
+ImageSource = Any
+_SIMILARITY_METHODS = ("correlation", "intersection")
+
+
+def _convert(rgb, space: str):
+    import cv2
+    if space == "hsv":
+        return (cv2.cvtColor(rgb, cv2.COLOR_RGB2HSV),
+                [[0, 180], [0, 256], [0, 256]])
+    if space == "rgb":
+        return rgb, [[0, 256], [0, 256], [0, 256]]
+    if space == "gray":
+        return cv2.cvtColor(rgb, cv2.COLOR_RGB2GRAY), [[0, 256]]
+    raise ValueError(f"unknown space: {space!r}")
+
+
+def image_histogram(haystack: Optional[ImageSource] = None, *,
+                    region: Optional[Sequence[int]] = None, bins: int = 32,
+                    space: str = "hsv") -> List[float]:
+    """Return a per-channel normalized colour histogram as a flat list of floats.
+
+    ``space`` is ``hsv`` / ``rgb`` / ``gray``; each channel contributes ``bins``
+    values (so HSV/RGB give ``3 * bins``). ``haystack`` defaults to a screen grab of
+    the optional ``region``.
+    """
+    import cv2
+    rgb = _to_rgb(haystack) if haystack is not None else _grab_rgb(region)
+    image, ranges = _convert(rgb, space)
+    channels = 1 if image.ndim == 2 else image.shape[2]
+    out: List[float] = []
+    for channel in range(channels):
+        hist = cv2.calcHist([image], [channel], None, [int(bins)], ranges[channel])
+        cv2.normalize(hist, hist, 0.0, 1.0, cv2.NORM_MINMAX)
+        out.extend(float(value) for value in hist.flatten())
+    return out
+
+
+def compare_histograms(hist_a: Sequence[float], hist_b: Sequence[float], *,
+                       method: str = "correlation") -> float:
+    """Compare two histograms. ``method``: correlation / chisqr / intersection / bhattacharyya.
+
+    For correlation / intersection higher means more similar; for chisqr /
+    bhattacharyya higher means more different.
+    """
+    import cv2
+    import numpy as np
+    methods = {"correlation": cv2.HISTCMP_CORREL,
+               "chisqr": cv2.HISTCMP_CHISQR,
+               "intersection": cv2.HISTCMP_INTERSECT,
+               "bhattacharyya": cv2.HISTCMP_BHATTACHARYYA}
+    if method not in methods:
+        raise ValueError(f"unknown method: {method!r}")
+    array_a = np.asarray(hist_a, dtype=np.float32)
+    array_b = np.asarray(hist_b, dtype=np.float32)
+    return round(float(cv2.compareHist(array_a, array_b, methods[method])), 4)
+
+
+def histogram_changed(reference: ImageSource,
+                      current: Optional[ImageSource] = None, *,
+                      region: Optional[Sequence[int]] = None,
+                      method: str = "correlation", threshold: float = 0.9,
+                      space: str = "hsv") -> bool:
+    """Return whether ``current`` (default: screen) differs from ``reference``.
+
+    Compares their histograms with ``method``; for similarity methods (correlation /
+    intersection) it is "changed" when the score drops below ``threshold``, for
+    distance methods (chisqr / bhattacharyya) when it rises above ``threshold``.
+    """
+    reference_hist = image_histogram(reference, space=space)
+    current_hist = (image_histogram(current, space=space) if current is not None
+                    else image_histogram(region=region, space=space))
+    score = compare_histograms(reference_hist, current_hist, method=method)
+    if method in _SIMILARITY_METHODS:
+        return score < float(threshold)
+    return score > float(threshold)

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3158,6 +3158,38 @@ def motion_regions_tools() -> List[MCPTool]:
     ]
 
 
+def window_zorder_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_set_topmost",
+            description=("Pin the window matching 'title' always-on-top (or release "
+                         "it with on=false). Returns {applied}. Windows only."),
+            input_schema=schema({
+                "title": {"type": "string"},
+                "on": {"type": "boolean"}},
+                required=["title"]),
+            handler=h.set_topmost,
+            annotations=SIDE_EFFECT_ONLY,
+        ),
+        MCPTool(
+            name="ac_bring_to_front",
+            description=("Raise the window matching 'title' to the top of the "
+                         "z-order. Returns {applied}. Windows only."),
+            input_schema=schema({"title": {"type": "string"}}, required=["title"]),
+            handler=h.bring_to_front,
+            annotations=SIDE_EFFECT_ONLY,
+        ),
+        MCPTool(
+            name="ac_send_to_back",
+            description=("Send the window matching 'title' to the bottom of the "
+                         "z-order. Returns {applied}. Windows only."),
+            input_schema=schema({"title": {"type": "string"}}, required=["title"]),
+            handler=h.send_to_back,
+            annotations=SIDE_EFFECT_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6664,7 +6696,7 @@ ALL_FACTORIES = (
     monitor_layout_tools, actionability_tools, element_parse_tools,
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
-    motion_regions_tools, plugin_sdk_tools, governance_tools,
+    motion_regions_tools, window_zorder_tools, plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3309,6 +3309,26 @@ def observation_tools() -> List[MCPTool]:
     ]
 
 
+def action_grounding_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_validate_action",
+            description=("Validate a coordinate 'action' {type,x,y,…} before "
+                         "dispatch: reject out-of-bounds clicks and, given 'targets' "
+                         "(element boxes), snap a near-miss onto the nearest "
+                         "element's centre. 'screen' [w,h] defaults to the live "
+                         "screen. Returns {ok, reason, snapped}."),
+            input_schema=schema({
+                "action": {"type": "object"},
+                "screen": {"type": "array", "items": {"type": "integer"}},
+                "targets": {"type": "array", "items": {"type": "object"}}},
+                required=["action"]),
+            handler=h.validate_action,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6817,7 +6837,7 @@ ALL_FACTORIES = (
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
     perceptual_diff_tools, window_geometry_tools, cua_action_tools,
-    observation_tools, plugin_sdk_tools, governance_tools,
+    observation_tools, action_grounding_tools, plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3231,6 +3231,33 @@ def perceptual_diff_tools() -> List[MCPTool]:
     ]
 
 
+def window_geometry_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_get_client_rect",
+            description=("The client-area rect [x,y,width,height] (screen coords, "
+                         "excluding title bar / borders) of the window matching "
+                         "'title'. Returns {found, rect}. Windows only."),
+            input_schema=schema({"title": {"type": "string"}}, required=["title"]),
+            handler=h.get_client_rect,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_client_point",
+            description=("Screen point for a client-area-local (x, y) inside the "
+                         "window 'title' — click inside it regardless of title-bar "
+                         "/ border thickness. Returns {found, point}."),
+            input_schema=schema({
+                "title": {"type": "string"},
+                "x": {"type": "integer"},
+                "y": {"type": "integer"}},
+                required=["title", "x", "y"]),
+            handler=h.client_point,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6738,7 +6765,8 @@ ALL_FACTORIES = (
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
-    perceptual_diff_tools, plugin_sdk_tools, governance_tools,
+    perceptual_diff_tools, window_geometry_tools, plugin_sdk_tools,
+    governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3345,6 +3345,38 @@ def agent_replay_tools() -> List[MCPTool]:
     ]
 
 
+def element_diff_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_match_elements",
+            description=("Geometry-aware match of two element-box lists ('before' / "
+                         "'after') by IoU. Returns {matched:[{before,after,iou}], "
+                         "added, removed} — tracks moves/renames where (role,name) "
+                         "diffing can't. 'iou_threshold'."),
+            input_schema=schema({
+                "before": {"type": "array", "items": {"type": "object"}},
+                "after": {"type": "array", "items": {"type": "object"}},
+                "iou_threshold": {"type": "number"}},
+                required=["before", "after"]),
+            handler=h.match_elements,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_assign_stable_ids",
+            description=("Tag 'elements' with a stable 'id' each, carried from a "
+                         "'prior' frame by IoU (a moved element keeps its id, a new "
+                         "one gets a fresh id). Returns {count, elements}."),
+            input_schema=schema({
+                "elements": {"type": "array", "items": {"type": "object"}},
+                "prior": {"type": "array", "items": {"type": "object"}},
+                "iou_threshold": {"type": "number"}},
+                required=["elements"]),
+            handler=h.assign_stable_ids,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6854,7 +6886,7 @@ ALL_FACTORIES = (
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
     perceptual_diff_tools, window_geometry_tools, cua_action_tools,
     observation_tools, action_grounding_tools, agent_replay_tools,
-    plugin_sdk_tools, governance_tools,
+    element_diff_tools, plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3329,6 +3329,22 @@ def action_grounding_tools() -> List[MCPTool]:
     ]
 
 
+def agent_replay_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_replay_trace",
+            description=("Replay a recorded agent trajectory: run each step's "
+                         "'action' (an AC action list) through the executor, in "
+                         "order. 'trace' is a JSON array or JSONL of {step, "
+                         "observation, action, result} steps. Returns {count, "
+                         "results}. Side-effecting (runs the actions)."),
+            input_schema=schema({"trace": {"type": "array"}}, required=["trace"]),
+            handler=h.replay_trace,
+            annotations=SIDE_EFFECT_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6837,7 +6853,8 @@ ALL_FACTORIES = (
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
     perceptual_diff_tools, window_geometry_tools, cua_action_tools,
-    observation_tools, action_grounding_tools, plugin_sdk_tools, governance_tools,
+    observation_tools, action_grounding_tools, agent_replay_tools,
+    plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3190,6 +3190,25 @@ def window_zorder_tools() -> List[MCPTool]:
     ]
 
 
+def soft_assert_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_soft_assert",
+            description=("Evaluate a list of 'checks' and aggregate ALL failures "
+                         "(don't stop at the first). Each is {value, op, expected, "
+                         "message}; op = eq/ne/gt/lt/contains/truthy. Returns "
+                         "{ok, passed, failures}; set 'raise_on_fail' to raise on "
+                         "any failure."),
+            input_schema=schema({
+                "checks": {"type": "array", "items": {"type": "object"}},
+                "raise_on_fail": {"type": "boolean"}},
+                required=["checks"]),
+            handler=h.soft_assert,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6696,7 +6715,8 @@ ALL_FACTORIES = (
     monitor_layout_tools, actionability_tools, element_parse_tools,
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
-    motion_regions_tools, window_zorder_tools, plugin_sdk_tools, governance_tools,
+    motion_regions_tools, window_zorder_tools, soft_assert_tools,
+    plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3578,6 +3578,52 @@ def rotated_match_tools() -> List[MCPTool]:
     ]
 
 
+def screen_grid_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_grid_cells",
+            description=("Lay an 'rows' x 'cols' labelled grid over the screen (or "
+                         "'region') for coarse VLM grounding. Returns {count, cells:"
+                         "[{label,row,col,left,top,right,bottom,center}]}; labels are "
+                         "spreadsheet-style ('A1' top-left)."),
+            input_schema=schema({
+                "rows": {"type": "integer"},
+                "cols": {"type": "integer"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["rows", "cols"]),
+            handler=h.grid_cells,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_cell_for_point",
+            description=("Return the grid cell containing point (x, y) over an 'rows' "
+                         "x 'cols' grid: {found, cell}. found=false if outside."),
+            input_schema=schema({
+                "x": {"type": "integer"},
+                "y": {"type": "integer"},
+                "rows": {"type": "integer"},
+                "cols": {"type": "integer"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["x", "y", "rows", "cols"]),
+            handler=h.cell_for_point,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_point_for_cell",
+            description=("Return the centre point {point:[x,y]} of grid cell 'label' "
+                         "(e.g. 'C3') over an 'rows' x 'cols' grid - ready to click."),
+            input_schema=schema({
+                "label": {"type": "string"},
+                "rows": {"type": "integer"},
+                "cols": {"type": "integer"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["label", "rows", "cols"]),
+            handler=h.point_for_cell,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def grid_locator_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6969,7 +7015,7 @@ ALL_FACTORIES = (
     process_doc_tools, tween_drag_tools, mouse_path_tools, field_entry_tools,
     key_hold_tools, mouse_relative_tools, text_unicode_tools,
     modifier_state_tools, grid_locator_tools, visual_match_tools,
-    rotated_match_tools,
+    rotated_match_tools, screen_grid_tools,
     color_region_tools, ssim_tools, feature_match_tools, shape_locator_tools,
     window_layout_tools, window_arrange_tools, preprocess_tools,
     monitor_layout_tools, actionability_tools, element_parse_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3086,6 +3086,43 @@ def rich_clipboard_tools() -> List[MCPTool]:
     ]
 
 
+def img_histogram_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_image_histogram",
+            description=("Per-channel normalized colour histogram of 'source' "
+                         "(image path; default screen grab of 'region'). 'space' "
+                         "hsv/rgb/gray, 'bins' per channel. Returns {bins, space, "
+                         "histogram}. A scale/illumination-robust view fingerprint."),
+            input_schema=schema({
+                "source": {"type": "string"},
+                "bins": {"type": "integer"},
+                "space": {"type": "string"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=[]),
+            handler=h.image_histogram,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_histogram_changed",
+            description=("Whether the screen / 'current' image differs from "
+                         "'reference' by colour histogram (theme switch, reload). "
+                         "'method' correlation/chisqr/intersection/bhattacharyya, "
+                         "'threshold', 'space'. Returns {changed, score}."),
+            input_schema=schema({
+                "reference": {"type": "string"},
+                "current": {"type": "string"},
+                "method": {"type": "string"},
+                "threshold": {"type": "number"},
+                "space": {"type": "string"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["reference"]),
+            handler=h.histogram_changed,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6591,7 +6628,8 @@ ALL_FACTORIES = (
     window_layout_tools, window_arrange_tools, preprocess_tools,
     monitor_layout_tools, actionability_tools, element_parse_tools,
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
-    locator_chain_tools, rich_clipboard_tools, plugin_sdk_tools, governance_tools,
+    locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
+    plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3410,6 +3410,24 @@ def element_scoring_tools() -> List[MCPTool]:
     ]
 
 
+def barcode_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_read_barcodes",
+            description=("Decode 1-D barcodes (EAN / UPC / Code-128) in 'source' "
+                         "(image path; default: screen grab of 'region'). Returns "
+                         "{count, barcodes:[{text, type, points}]}. QR codes have "
+                         "their own tool."),
+            input_schema=schema({
+                "source": {"type": "string"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=[]),
+            handler=h.read_barcodes,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6919,7 +6937,8 @@ ALL_FACTORIES = (
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
     perceptual_diff_tools, window_geometry_tools, cua_action_tools,
     observation_tools, action_grounding_tools, agent_replay_tools,
-    element_diff_tools, element_scoring_tools, plugin_sdk_tools, governance_tools,
+    element_diff_tools, element_scoring_tools, barcode_tools, plugin_sdk_tools,
+    governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3538,6 +3538,46 @@ def visual_match_tools() -> List[MCPTool]:
     ]
 
 
+def rotated_match_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_match_rotated",
+            description=("Find 'template' on screen tolerating ROTATION and scale: "
+                         "sweeps 'angles' (degrees, e.g. [-10,0,10]) x 'scales', "
+                         "returns the best {found, match:{x,y,width,height,score,"
+                         "scale,angle,center}}. Use when a control is skewed / a "
+                         "rotated icon / a dial. 'min_score', 'region', 'method'."),
+            input_schema=schema({
+                "template": {"type": "string"},
+                "min_score": {"type": "number"},
+                "scales": {"type": "array", "items": {"type": "number"}},
+                "angles": {"type": "array", "items": {"type": "number"}},
+                "region": {"type": "array", "items": {"type": "integer"}},
+                "method": {"type": "string"}},
+                required=["template"]),
+            handler=h.match_rotated,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_match_rotated_all",
+            description=("Find EVERY rotation/scale-tolerant match of 'template' "
+                         ">= 'min_score' over the angle x scale sweep, overlaps "
+                         "removed by NMS. Returns {count, matches}."),
+            input_schema=schema({
+                "template": {"type": "string"},
+                "min_score": {"type": "number"},
+                "scales": {"type": "array", "items": {"type": "number"}},
+                "angles": {"type": "array", "items": {"type": "number"}},
+                "max_results": {"type": "integer"},
+                "nms_iou": {"type": "number"},
+                "region": {"type": "array", "items": {"type": "integer"}}},
+                required=["template"]),
+            handler=h.match_rotated_all,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def grid_locator_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6929,6 +6969,7 @@ ALL_FACTORIES = (
     process_doc_tools, tween_drag_tools, mouse_path_tools, field_entry_tools,
     key_hold_tools, mouse_relative_tools, text_unicode_tools,
     modifier_state_tools, grid_locator_tools, visual_match_tools,
+    rotated_match_tools,
     color_region_tools, ssim_tools, feature_match_tools, shape_locator_tools,
     window_layout_tools, window_arrange_tools, preprocess_tools,
     monitor_layout_tools, actionability_tools, element_parse_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3086,6 +3086,31 @@ def rich_clipboard_tools() -> List[MCPTool]:
     ]
 
 
+def clipboard_files_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_set_clipboard_files",
+            description=("Put a file-drop list on the clipboard as CF_HDROP so the "
+                         "files can be pasted (Ctrl+V) into Explorer / apps as a real "
+                         "file copy (Windows). 'paths' is a list of absolute paths. "
+                         "Returns {set, count}."),
+            input_schema=schema({
+                "paths": {"type": "array", "items": {"type": "string"}}},
+                required=["paths"]),
+            handler=h.set_clipboard_files,
+            annotations=SIDE_EFFECT_ONLY,
+        ),
+        MCPTool(
+            name="ac_get_clipboard_files",
+            description=("Read the clipboard's file-drop list (CF_HDROP, Windows). "
+                         "Returns {found, paths}."),
+            input_schema=schema({}, required=[]),
+            handler=h.get_clipboard_files,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def img_histogram_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -7020,7 +7045,8 @@ ALL_FACTORIES = (
     window_layout_tools, window_arrange_tools, preprocess_tools,
     monitor_layout_tools, actionability_tools, element_parse_tools,
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
-    locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
+    locator_chain_tools, rich_clipboard_tools, clipboard_files_tools,
+    img_histogram_tools,
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
     perceptual_diff_tools, window_geometry_tools, cua_action_tools,
     observation_tools, action_grounding_tools, agent_replay_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3258,6 +3258,24 @@ def window_geometry_tools() -> List[MCPTool]:
     ]
 
 
+def cua_action_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_cua_command",
+            description=("Normalize a computer-use action 'payload' from 'source' "
+                         "(anthropic / openai / canonical) and map it to a runnable "
+                         "AC_* command. Returns {canonical, command:[name, params]}. "
+                         "Bridges Anthropic/OpenAI agent outputs to AutoControl."),
+            input_schema=schema({
+                "payload": {"type": "object"},
+                "source": {"type": "string"}},
+                required=["payload"]),
+            handler=h.cua_command,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6765,8 +6783,8 @@ ALL_FACTORIES = (
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
-    perceptual_diff_tools, window_geometry_tools, plugin_sdk_tools,
-    governance_tools,
+    perceptual_diff_tools, window_geometry_tools, cua_action_tools,
+    plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3123,6 +3123,41 @@ def img_histogram_tools() -> List[MCPTool]:
     ]
 
 
+def motion_regions_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_changed_regions",
+            description=("Boxes of regions that MOVED between 'before' (image path) "
+                         "and 'after' (path; default: the live screen) via absdiff. "
+                         "Returns {count, regions}. For spinners / animations / "
+                         "picking a quiet area. 'threshold'/'min_area'/'blur'."),
+            input_schema=schema({
+                "before": {"type": "string"},
+                "after": {"type": "string"},
+                "threshold": {"type": "integer"},
+                "min_area": {"type": "integer"},
+                "blur": {"type": "integer"}},
+                required=["before"]),
+            handler=h.changed_regions,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_has_motion",
+            description=("Whether anything moved between 'before' and 'after' "
+                         "(default: screen). Returns {moved, activity} where "
+                         "activity is the fraction of pixels that changed."),
+            input_schema=schema({
+                "before": {"type": "string"},
+                "after": {"type": "string"},
+                "threshold": {"type": "integer"},
+                "min_area": {"type": "integer"}},
+                required=["before"]),
+            handler=h.has_motion,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6629,7 +6664,7 @@ ALL_FACTORIES = (
     monitor_layout_tools, actionability_tools, element_parse_tools,
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
-    plugin_sdk_tools, governance_tools,
+    motion_regions_tools, plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3377,6 +3377,39 @@ def element_diff_tools() -> List[MCPTool]:
     ]
 
 
+def element_scoring_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_score_candidates",
+            description=("Rank candidate element boxes best-first by a weighted mean "
+                         "of role match ('want_role'), fuzzy name similarity "
+                         "('want_name'), 'anchor' proximity and enabled-state. "
+                         "Returns {count, scored:[{element, score, matched_on}]}."),
+            input_schema=schema({
+                "candidates": {"type": "array", "items": {"type": "object"}},
+                "want_role": {"type": "string"},
+                "want_name": {"type": "string"},
+                "anchor": {"type": "array", "items": {"type": "integer"}}},
+                required=["candidates"]),
+            handler=h.score_candidates,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_best_candidate",
+            description=("The single highest-scoring candidate element by role / "
+                         "name / proximity. Returns {found, best}."),
+            input_schema=schema({
+                "candidates": {"type": "array", "items": {"type": "object"}},
+                "want_role": {"type": "string"},
+                "want_name": {"type": "string"},
+                "anchor": {"type": "array", "items": {"type": "integer"}}},
+                required=["candidates"]),
+            handler=h.best_candidate,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6886,7 +6919,7 @@ ALL_FACTORIES = (
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
     perceptual_diff_tools, window_geometry_tools, cua_action_tools,
     observation_tools, action_grounding_tools, agent_replay_tools,
-    element_diff_tools, plugin_sdk_tools, governance_tools,
+    element_diff_tools, element_scoring_tools, plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3209,6 +3209,28 @@ def soft_assert_tools() -> List[MCPTool]:
     ]
 
 
+def perceptual_diff_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_perceptual_diff",
+            description=("Perceptual (YIQ) diff of 'actual' vs 'expected' image "
+                         "paths. By default suppresses anti-aliased edge diffs "
+                         "(include_aa=true to keep them). Returns {diff_pixels, "
+                         "total_pixels, diff_ratio, regions}; pass 'max_diff_ratio' "
+                         "to raise when exceeded. 'threshold' 0..1 sensitivity."),
+            input_schema=schema({
+                "actual": {"type": "string"},
+                "expected": {"type": "string"},
+                "threshold": {"type": "number"},
+                "include_aa": {"type": "boolean"},
+                "max_diff_ratio": {"type": "number"}},
+                required=["actual", "expected"]),
+            handler=h.perceptual_diff,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6716,7 +6738,7 @@ ALL_FACTORIES = (
     hsv_segment_tools, text_regions_tools, edge_lines_tools, expect_poll_tools,
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
-    plugin_sdk_tools, governance_tools,
+    perceptual_diff_tools, plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_factories.py
+++ b/je_auto_control/utils/mcp_server/tools/_factories.py
@@ -3276,6 +3276,39 @@ def cua_action_tools() -> List[MCPTool]:
     ]
 
 
+def observation_tools() -> List[MCPTool]:
+    return [
+        MCPTool(
+            name="ac_serialize_observation",
+            description=("Render an indexed a11y text observation from 'elements' "
+                         "(role/name/x/y/width/height dicts, optionally nested): "
+                         "'[i] role \"name\" @(cx,cy)' lines, interactive-only, "
+                         "viewport-clipped, capped at 'max_elements'. Returns "
+                         "{observation, count} — feed it to a VLM, act by index."),
+            input_schema=schema({
+                "elements": {"type": "array", "items": {"type": "object"}},
+                "viewport": {"type": "array", "items": {"type": "integer"}},
+                "max_elements": {"type": "integer"}},
+                required=["elements"]),
+            handler=h.serialize_observation,
+            annotations=READ_ONLY,
+        ),
+        MCPTool(
+            name="ac_observation_index",
+            description=("The on-screen elements in reading order, viewport-clipped "
+                         "and capped, each with a stable 'index'. Returns {count, "
+                         "elements} — the structured form behind the observation."),
+            input_schema=schema({
+                "elements": {"type": "array", "items": {"type": "object"}},
+                "viewport": {"type": "array", "items": {"type": "integer"}},
+                "max_elements": {"type": "integer"}},
+                required=["elements"]),
+            handler=h.observation_index,
+            annotations=READ_ONLY,
+        ),
+    ]
+
+
 def ssim_tools() -> List[MCPTool]:
     return [
         MCPTool(
@@ -6784,7 +6817,7 @@ ALL_FACTORIES = (
     locator_chain_tools, rich_clipboard_tools, img_histogram_tools,
     motion_regions_tools, window_zorder_tools, soft_assert_tools,
     perceptual_diff_tools, window_geometry_tools, cua_action_tools,
-    plugin_sdk_tools, governance_tools,
+    observation_tools, plugin_sdk_tools, governance_tools,
     credential_lease_tools, egress_tools, approval_testing_tools,
     trajectory_eval_tools, compliance_tools, agent_trace_tools,
     video_report_tools, fuzzy_tools, artifact_store_tools, image_dedup_tools,

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2288,6 +2288,12 @@ def soft_assert(checks, raise_on_fail=False):
     return _soft_assert(checks, raise_on_fail)
 
 
+def perceptual_diff(actual, expected, threshold=0.1, include_aa=False,
+                    max_diff_ratio=None):
+    from je_auto_control.utils.executor.action_executor import _perceptual_diff
+    return _perceptual_diff(actual, expected, threshold, include_aa, max_diff_ratio)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2350,6 +2350,11 @@ def best_candidate(candidates, want_role=None, want_name=None, anchor=None):
     return _best_candidate(candidates, want_role, want_name, anchor)
 
 
+def read_barcodes(source=None, region=None):
+    from je_auto_control.utils.executor.action_executor import _read_barcodes
+    return _read_barcodes(source, region)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2294,6 +2294,16 @@ def perceptual_diff(actual, expected, threshold=0.1, include_aa=False,
     return _perceptual_diff(actual, expected, threshold, include_aa, max_diff_ratio)
 
 
+def get_client_rect(title):
+    from je_auto_control.utils.executor.action_executor import _get_client_rect
+    return _get_client_rect(title)
+
+
+def client_point(title, x, y):
+    from je_auto_control.utils.executor.action_executor import _client_point
+    return _client_point(title, x, y)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2320,6 +2320,11 @@ def observation_index(elements, viewport=None, max_elements=80):
     return _observation_index(elements, viewport, max_elements)
 
 
+def validate_action(action, screen=None, targets=None):
+    from je_auto_control.utils.executor.action_executor import _validate_action
+    return _validate_action(action, screen, targets)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2283,6 +2283,11 @@ def send_to_back(title):
     return _send_to_back(title)
 
 
+def soft_assert(checks, raise_on_fail=False):
+    from je_auto_control.utils.executor.action_executor import _soft_assert
+    return _soft_assert(checks, raise_on_fail)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2268,6 +2268,21 @@ def has_motion(before, after=None, threshold=25, min_area=80):
     return _has_motion(before, after, threshold, min_area)
 
 
+def set_topmost(title, on=True):
+    from je_auto_control.utils.executor.action_executor import _set_topmost
+    return _set_topmost(title, on)
+
+
+def bring_to_front(title):
+    from je_auto_control.utils.executor.action_executor import _bring_to_front
+    return _bring_to_front(title)
+
+
+def send_to_back(title):
+    from je_auto_control.utils.executor.action_executor import _send_to_back
+    return _send_to_back(title)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2108,6 +2108,21 @@ def match_rotated_all(template, min_score=0.8, scales=None, angles=None,
                               nms_iou, region)
 
 
+def grid_cells(rows, cols, region=None):
+    from je_auto_control.utils.executor.action_executor import _grid_cells
+    return _grid_cells(rows, cols, region)
+
+
+def cell_for_point(x, y, rows, cols, region=None):
+    from je_auto_control.utils.executor.action_executor import _cell_for_point
+    return _cell_for_point(x, y, rows, cols, region)
+
+
+def point_for_cell(label, rows, cols, region=None):
+    from je_auto_control.utils.executor.action_executor import _point_for_cell
+    return _point_for_cell(label, rows, cols, region)
+
+
 def find_color_region(rgb, tolerance=20, min_area=50, region=None):
     from je_auto_control.utils.executor.action_executor import (
         _find_color_region)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2330,6 +2330,16 @@ def replay_trace(trace):
     return _replay_trace(trace)
 
 
+def match_elements(before, after, iou_threshold=0.5):
+    from je_auto_control.utils.executor.action_executor import _match_elements
+    return _match_elements(before, after, iou_threshold)
+
+
+def assign_stable_ids(elements, prior=None, iou_threshold=0.5):
+    from je_auto_control.utils.executor.action_executor import _assign_stable_ids
+    return _assign_stable_ids(elements, prior, iou_threshold)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2094,6 +2094,20 @@ def match_masked_all(template, mask=None, min_score=0.9, max_results=20,
                              region)
 
 
+def match_rotated(template, min_score=0.8, scales=None, angles=None,
+                  region=None, method="ccoeff_normed"):
+    from je_auto_control.utils.executor.action_executor import _match_rotated
+    return _match_rotated(template, min_score, scales, angles, region, method)
+
+
+def match_rotated_all(template, min_score=0.8, scales=None, angles=None,
+                      max_results=20, nms_iou=0.3, region=None):
+    from je_auto_control.utils.executor.action_executor import (
+        _match_rotated_all)
+    return _match_rotated_all(template, min_score, scales, angles, max_results,
+                              nms_iou, region)
+
+
 def find_color_region(rgb, tolerance=20, min_area=50, region=None):
     from je_auto_control.utils.executor.action_executor import (
         _find_color_region)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2247,6 +2247,17 @@ def get_clipboard_html():
     return _get_clipboard_html()
 
 
+def image_histogram(source=None, bins=32, space="hsv", region=None):
+    from je_auto_control.utils.executor.action_executor import _image_histogram
+    return _image_histogram(source, bins, space, region)
+
+
+def histogram_changed(reference, current=None, method="correlation",
+                      threshold=0.9, space="hsv", region=None):
+    from je_auto_control.utils.executor.action_executor import _histogram_changed
+    return _histogram_changed(reference, current, method, threshold, space, region)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2276,6 +2276,16 @@ def get_clipboard_html():
     return _get_clipboard_html()
 
 
+def set_clipboard_files(paths):
+    from je_auto_control.utils.executor.action_executor import _set_clipboard_files
+    return _set_clipboard_files(paths)
+
+
+def get_clipboard_files():
+    from je_auto_control.utils.executor.action_executor import _get_clipboard_files
+    return _get_clipboard_files()
+
+
 def image_histogram(source=None, bins=32, space="hsv", region=None):
     from je_auto_control.utils.executor.action_executor import _image_histogram
     return _image_histogram(source, bins, space, region)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2325,6 +2325,11 @@ def validate_action(action, screen=None, targets=None):
     return _validate_action(action, screen, targets)
 
 
+def replay_trace(trace):
+    from je_auto_control.utils.executor.action_executor import _replay_trace
+    return _replay_trace(trace)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2309,6 +2309,17 @@ def cua_command(payload, source="canonical"):
     return _cua_command(payload, source)
 
 
+def serialize_observation(elements, viewport=None, max_elements=80):
+    from je_auto_control.utils.executor.action_executor import (
+        _serialize_observation)
+    return _serialize_observation(elements, viewport, max_elements)
+
+
+def observation_index(elements, viewport=None, max_elements=80):
+    from je_auto_control.utils.executor.action_executor import _observation_index
+    return _observation_index(elements, viewport, max_elements)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2258,6 +2258,16 @@ def histogram_changed(reference, current=None, method="correlation",
     return _histogram_changed(reference, current, method, threshold, space, region)
 
 
+def changed_regions(before, after=None, threshold=25, min_area=80, blur=5):
+    from je_auto_control.utils.executor.action_executor import _changed_regions
+    return _changed_regions(before, after, threshold, min_area, blur)
+
+
+def has_motion(before, after=None, threshold=25, min_area=80):
+    from je_auto_control.utils.executor.action_executor import _has_motion
+    return _has_motion(before, after, threshold, min_area)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2304,6 +2304,11 @@ def client_point(title, x, y):
     return _client_point(title, x, y)
 
 
+def cua_command(payload, source="canonical"):
+    from je_auto_control.utils.executor.action_executor import _cua_command
+    return _cua_command(payload, source)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/mcp_server/tools/_handlers.py
+++ b/je_auto_control/utils/mcp_server/tools/_handlers.py
@@ -2340,6 +2340,16 @@ def assign_stable_ids(elements, prior=None, iou_threshold=0.5):
     return _assign_stable_ids(elements, prior, iou_threshold)
 
 
+def score_candidates(candidates, want_role=None, want_name=None, anchor=None):
+    from je_auto_control.utils.executor.action_executor import _score_candidates
+    return _score_candidates(candidates, want_role, want_name, anchor)
+
+
+def best_candidate(candidates, want_role=None, want_name=None, anchor=None):
+    from je_auto_control.utils.executor.action_executor import _best_candidate
+    return _best_candidate(candidates, want_role, want_name, anchor)
+
+
 def detect_drift(reference, current, threshold=0.25, bins=10):
     from je_auto_control.utils.executor.action_executor import _detect_drift
     return _detect_drift(reference, current, threshold, bins)

--- a/je_auto_control/utils/motion_regions/__init__.py
+++ b/je_auto_control/utils/motion_regions/__init__.py
@@ -1,0 +1,6 @@
+"""Localized change / activity detection between two frames (absdiff)."""
+from je_auto_control.utils.motion_regions.motion_regions import (
+    activity_score, changed_regions, has_motion,
+)
+
+__all__ = ["activity_score", "changed_regions", "has_motion"]

--- a/je_auto_control/utils/motion_regions/motion_regions.py
+++ b/je_auto_control/utils/motion_regions/motion_regions.py
@@ -1,0 +1,67 @@
+"""Localized change / activity detection between two frames (cheap absdiff).
+
+Three near-neighbours, all distinct: ``wait_until_screen_stable`` returns a *boolean*
+over a live poll loop (not localized boxes on an injectable pair); ``ssim_changed_regions``
+is *structural* (Gaussian-windowed SSIM, illumination-tolerant — deliberately ignores
+the fast pixel motion you'd want for "where is the spinner / video / animation");
+``diff_screenshots`` highlights pixel diffs but is not framed as activity blobs with a
+score. This is the cheap absdiff path: which sub-regions are *moving* right now, so a
+script can pick a quiet region or locate a busy spinner.
+
+Operates on two injectable frames (ndarray / path / PIL), so it is headless-testable on
+synthetic arrays. OpenCV + NumPy come in via ``je_open_cv``; reuses the shared
+connected-component helper. Imports no ``PySide6``.
+"""
+from typing import Any, Dict, List
+
+from je_auto_control.utils.visual_match.visual_match import _to_gray
+
+ImageSource = Any
+
+
+def _diff_mask(before: ImageSource, after: ImageSource, threshold: int, blur: int):
+    """Return the binary motion mask between two frames (same size required)."""
+    import cv2
+    first = _to_gray(before)
+    second = _to_gray(after)
+    if first.shape != second.shape:
+        raise ValueError(f"frames must be the same size: {first.shape} vs "
+                         f"{second.shape}")
+    if int(blur) > 0:
+        kernel = int(blur) | 1
+        first = cv2.GaussianBlur(first, (kernel, kernel), 0)
+        second = cv2.GaussianBlur(second, (kernel, kernel), 0)
+    _retval, mask = cv2.threshold(cv2.absdiff(first, second), int(threshold), 255,
+                                  cv2.THRESH_BINARY)
+    return mask
+
+
+def changed_regions(before: ImageSource, after: ImageSource, *,
+                    threshold: int = 25, min_area: int = 80,
+                    blur: int = 5) -> List[Dict[str, Any]]:
+    """Return boxes of the regions that moved between ``before`` and ``after``.
+
+    A pixel counts as moved where the absolute difference exceeds ``threshold``;
+    connected moved pixels covering at least ``min_area`` are returned as
+    ``{x, y, width, height, area, center}`` largest first. ``blur`` denoises first.
+    """
+    import cv2
+    from je_auto_control.utils.cv2_utils.blobs import connected_boxes
+    mask = _diff_mask(before, after, threshold, blur)
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3))
+    mask = cv2.dilate(mask, kernel, iterations=2)
+    return connected_boxes(mask, int(min_area))
+
+
+def has_motion(before: ImageSource, after: ImageSource, *, threshold: int = 25,
+               min_area: int = 80) -> bool:
+    """Return whether any region of at least ``min_area`` moved between the frames."""
+    return bool(changed_regions(before, after, threshold=threshold,
+                                min_area=min_area))
+
+
+def activity_score(before: ImageSource, after: ImageSource, *,
+                   threshold: int = 25) -> float:
+    """Return the fraction (0..1) of pixels that moved between the two frames."""
+    mask = _diff_mask(before, after, threshold, 0)
+    return round(float((mask > 0).sum()) / mask.size, 4)

--- a/je_auto_control/utils/observation/__init__.py
+++ b/je_auto_control/utils/observation/__init__.py
@@ -1,0 +1,6 @@
+"""Token-budgeted, indexed a11y text observation for VLM/agent grounding."""
+from je_auto_control.utils.observation.observation import (
+    flatten_tree, observation_index, serialize_observation,
+)
+
+__all__ = ["flatten_tree", "observation_index", "serialize_observation"]

--- a/je_auto_control/utils/observation/observation.py
+++ b/je_auto_control/utils/observation/observation.py
@@ -1,0 +1,86 @@
+"""Token-budgeted, indexed a11y text observation — what to feed a VLM/agent.
+
+``screen_state.describe_screen`` returns role *counts* plus a flat list of control
+labels — but no stable per-element index, no ``[12] button "Submit" @(x,y)`` lines, no
+viewport clipping, and no element cap / token budget. Modern desktop/web agents feed a
+*flattened, indexed, viewport-pruned* text block (the "accessibility tree as the text
+observation" pattern), then act by index ("click [12]"). This builds that observation
+and the index behind it, pairing with :doc:`element_parse` and ``set_of_marks``.
+
+Pure-stdlib over plain element dicts (``role`` / ``name`` / ``x`` / ``y`` / ``width`` /
+``height``, optionally nested ``children``), so it is fully unit-testable. Imports no
+``PySide6``.
+"""
+from typing import Any, Dict, List, Optional, Sequence
+
+Element = Dict[str, Any]
+_INTERACTIVE = {"button", "link", "textbox", "edit", "textfield", "checkbox",
+                "radio", "menuitem", "tab", "combobox", "listitem", "switch",
+                "slider", "menu", "option"}
+
+
+def _center(element: Element) -> List[int]:
+    return [int(element.get("x", 0)) + int(element.get("width", 0)) // 2,
+            int(element.get("y", 0)) + int(element.get("height", 0)) // 2]
+
+
+def flatten_tree(elements: Sequence[Element], *,
+                 interactive_only: bool = True) -> List[Element]:
+    """Flatten a (possibly nested ``children``) element tree to a flat list.
+
+    With ``interactive_only`` (default) only actionable roles (button, link, textbox,
+    …) survive. Each returned node drops its ``children`` key.
+    """
+    flat: List[Element] = []
+
+    def walk(items: Sequence[Element]) -> None:
+        for element in items:
+            flat.append({key: value for key, value in element.items()
+                         if key != "children"})
+            if element.get("children"):
+                walk(element["children"])
+
+    walk(elements)
+    if interactive_only:
+        flat = [e for e in flat if str(e.get("role", "")).lower() in _INTERACTIVE]
+    return flat
+
+
+def _in_viewport(element: Element, viewport: Optional[Sequence[int]]) -> bool:
+    if not viewport:
+        return True
+    vx, vy, vw, vh = (int(v) for v in viewport[:4])
+    cx, cy = _center(element)
+    return vx <= cx <= vx + vw and vy <= cy <= vy + vh
+
+
+def observation_index(elements: Sequence[Element], *,
+                      viewport: Optional[Sequence[int]] = None,
+                      max_elements: int = 80,
+                      interactive_only: bool = True) -> List[Element]:
+    """Return the on-screen elements in reading order, capped, each with an ``index``.
+
+    Flattens the tree, keeps only elements whose centre is inside ``viewport`` (if
+    given), orders them top-to-bottom / left-to-right, caps at ``max_elements`` and
+    assigns a stable ``index`` an agent can refer to.
+    """
+    from je_auto_control.utils.element_parse import reading_order
+    flat = flatten_tree(elements, interactive_only=interactive_only)
+    visible = [e for e in flat if _in_viewport(e, viewport)]
+    ordered = reading_order(visible)[:int(max_elements)]
+    return [dict(element, index=index) for index, element in enumerate(ordered)]
+
+
+def serialize_observation(elements: Sequence[Element], *,
+                          viewport: Optional[Sequence[int]] = None,
+                          max_elements: int = 80,
+                          interactive_only: bool = True) -> str:
+    """Render the indexed observation as ``[i] role "name" @(cx,cy)`` lines."""
+    lines = []
+    for element in observation_index(elements, viewport=viewport,
+                                     max_elements=max_elements,
+                                     interactive_only=interactive_only):
+        cx, cy = _center(element)
+        lines.append(f'[{element["index"]}] {element.get("role", "element")} '
+                     f'"{element.get("name", "")}" @({cx},{cy})')
+    return "\n".join(lines)

--- a/je_auto_control/utils/perceptual_diff/__init__.py
+++ b/je_auto_control/utils/perceptual_diff/__init__.py
@@ -1,0 +1,6 @@
+"""Perceptual (YIQ) image diff with anti-alias edge suppression."""
+from je_auto_control.utils.perceptual_diff.perceptual_diff import (
+    PerceptualDiffResult, assert_perceptual, perceptual_diff,
+)
+
+__all__ = ["PerceptualDiffResult", "assert_perceptual", "perceptual_diff"]

--- a/je_auto_control/utils/perceptual_diff/perceptual_diff.py
+++ b/je_auto_control/utils/perceptual_diff/perceptual_diff.py
@@ -1,0 +1,94 @@
+"""Perceptual (YIQ) image diff with anti-alias edge suppression.
+
+``visual_regression.image_difference`` counts raw per-channel max-delta pixels and
+``ssim`` gives a global structural score. Neither uses a *perceptual* colour metric, and
+neither ignores **anti-aliased edges** — the #1 source of false-positive visual-diff
+failures across DPI / font-hinting. This compares pixels in YIQ space (the pixelmatch
+colour metric, far closer to human perception than RGB) and, by default, suppresses the
+thin one-pixel edge differences that anti-aliasing produces via a morphological open, so
+only *solid* changed regions count.
+
+Runs on an injectable image pair (ndarray / path / PIL), so it is headless-testable on
+synthetic arrays. OpenCV + NumPy come in via ``je_open_cv``; reuses the shared
+connected-component helper and the RGB loader. Imports no ``PySide6``.
+"""
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+# Reuse the RGB loader (single source of truth, no copy).
+from je_auto_control.utils.color_region.color_region import _to_rgb
+
+ImageSource = Any
+_MAX_YIQ_DELTA = 35215.0          # pixelmatch: max possible YIQ delta for 255 diff
+
+
+@dataclass(frozen=True)
+class PerceptualDiffResult:
+    """The outcome of a perceptual diff: changed-pixel count, ratio and regions."""
+
+    diff_pixels: int
+    total_pixels: int
+    diff_ratio: float
+    regions: List[Dict[str, Any]]
+
+
+def _yiq_delta(first, second):
+    """Return the per-pixel squared YIQ colour distance between two RGB float images."""
+    weights_y = (0.29889531, 0.58662247, 0.11448223)
+    weights_i = (0.59597799, -0.27417610, -0.32180189)
+    weights_q = (0.21147017, -0.52261711, 0.31114694)
+
+    def channel(image, weights):
+        return (image[..., 0] * weights[0] + image[..., 1] * weights[1]
+                + image[..., 2] * weights[2])
+
+    delta_y = channel(first, weights_y) - channel(second, weights_y)
+    delta_i = channel(first, weights_i) - channel(second, weights_i)
+    delta_q = channel(first, weights_q) - channel(second, weights_q)
+    return 0.5053 * delta_y ** 2 + 0.299 * delta_i ** 2 + 0.1957 * delta_q ** 2
+
+
+def perceptual_diff(actual: ImageSource, expected: ImageSource, *,
+                    threshold: float = 0.1, include_aa: bool = False,
+                    min_area: int = 1) -> PerceptualDiffResult:
+    """Compare two images perceptually; return the changed pixels, ratio and regions.
+
+    ``threshold`` (0..1) is the pixelmatch sensitivity — higher tolerates more colour
+    difference before a pixel counts as changed. When ``include_aa`` is False (default)
+    a morphological open removes thin anti-aliased edge differences so only solid
+    changes remain. Different-sized images raise ``ValueError``.
+    """
+    import cv2
+    import numpy as np
+    from je_auto_control.utils.cv2_utils.blobs import connected_boxes
+    first = _to_rgb(actual).astype(np.float64)
+    second = _to_rgb(expected).astype(np.float64)
+    if first.shape != second.shape:
+        raise ValueError(f"images must be the same size: {first.shape} vs "
+                         f"{second.shape}")
+    max_delta = _MAX_YIQ_DELTA * float(threshold) * float(threshold)
+    mask = (_yiq_delta(first, second) > max_delta).astype(np.uint8)
+    if not include_aa:
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3))
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
+    diff_pixels = int(np.count_nonzero(mask))
+    total = int(mask.size)
+    regions = connected_boxes(mask * 255, int(min_area))
+    return PerceptualDiffResult(diff_pixels, total,
+                                round(diff_pixels / total, 6) if total else 0.0,
+                                regions)
+
+
+def assert_perceptual(actual: ImageSource, expected: ImageSource, *,
+                      threshold: float = 0.1, include_aa: bool = False,
+                      max_diff_ratio: float = 0.0) -> PerceptualDiffResult:
+    """Like :func:`perceptual_diff` but raise when the diff ratio exceeds ``max_diff_ratio``."""
+    from je_auto_control.utils.exception.exceptions import (
+        AutoControlActionException)
+    result = perceptual_diff(actual, expected, threshold=threshold,
+                             include_aa=include_aa)
+    if result.diff_ratio > float(max_diff_ratio):
+        raise AutoControlActionException(
+            f"perceptual diff {result.diff_ratio} exceeds {max_diff_ratio} "
+            f"({result.diff_pixels} pixels changed)")
+    return result

--- a/je_auto_control/utils/rotated_match/__init__.py
+++ b/je_auto_control/utils/rotated_match/__init__.py
@@ -1,0 +1,6 @@
+"""Rotation- and scale-tolerant template matching (scale-space x angle sweep)."""
+from je_auto_control.utils.rotated_match.rotated_match import (
+    RotatedMatch, match_rotated, match_rotated_all, scale_space,
+)
+
+__all__ = ["RotatedMatch", "match_rotated", "match_rotated_all", "scale_space"]

--- a/je_auto_control/utils/rotated_match/rotated_match.py
+++ b/je_auto_control/utils/rotated_match/rotated_match.py
@@ -1,0 +1,139 @@
+"""Rotation- and scale-tolerant template matching.
+
+``visual_match`` searches a template across *scales* (DPI / zoom tolerance) but
+assumes the template is axis-aligned — a control that is rendered at a slight skew,
+a rotated icon, or a knob/dial at a different angle is missed because OpenCV's
+``matchTemplate`` is not rotation-invariant. This sweeps a set of rotation
+*angles* (each warped with ``cv2.warpAffine``) crossed with a scale-space
+(``np.linspace`` pyramid), correlates every (scale, angle) candidate and keeps the
+best — reporting the winning ``angle`` and ``scale`` so the caller knows the pose.
+
+It reuses ``visual_match``'s grayscale loaders, scale resize, correlation method
+table and non-maximum suppression, so no matching or geometry code is duplicated.
+The ``haystack`` is injectable (ndarray / path / PIL), so the search is unit-testable
+on synthetic arrays; only the default (grab the screen) is device-bound. OpenCV +
+NumPy arrive via the project's ``je_open_cv`` dependency and are imported lazily.
+Imports no ``PySide6``.
+"""
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+from je_auto_control.utils.visual_match.visual_match import (
+    _haystack_gray, _method, _nms, _resize, _to_gray,
+)
+
+ImageSource = Any
+
+
+@dataclass(frozen=True)
+class RotatedMatch:
+    """One match with its recovered pose: top-left, size, score, scale, angle."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+    score: float
+    scale: float
+    angle: float
+
+    @property
+    def center(self) -> List[int]:
+        """The match's centre point ``[x, y]`` (ready to click)."""
+        return [self.x + self.width // 2, self.y + self.height // 2]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the match as a plain dict including the centre point."""
+        data = asdict(self)
+        data["center"] = self.center
+        return data
+
+
+def _rotate(template, angle: float):
+    """Rotate ``template`` by ``angle`` degrees, expanding the canvas to fit it."""
+    import cv2
+    if abs(angle) < 1e-9:
+        return template
+    height, width = template.shape[:2]
+    center = (width / 2.0, height / 2.0)
+    matrix = cv2.getRotationMatrix2D(center, float(angle), 1.0)
+    cos = abs(matrix[0, 0])
+    sin = abs(matrix[0, 1])
+    new_w = int(height * sin + width * cos)
+    new_h = int(height * cos + width * sin)
+    matrix[0, 2] += (new_w / 2.0) - center[0]
+    matrix[1, 2] += (new_h / 2.0) - center[1]
+    return cv2.warpAffine(template, matrix, (new_w, new_h))
+
+
+def scale_space(min_scale: float = 0.8, max_scale: float = 1.25,
+                steps: int = 5) -> List[float]:
+    """Return ``steps`` evenly spaced scales in ``[min_scale, max_scale]``."""
+    import numpy as np
+    return [round(float(s), 4)
+            for s in np.linspace(float(min_scale), float(max_scale), int(steps))]
+
+
+def _best_at(hay, tmpl, scale: float, angle: float, metric: int):
+    """Return the best ``RotatedMatch`` for one (scale, angle), or ``None``."""
+    import cv2
+    warped = _rotate(_resize(tmpl, float(scale)), float(angle))
+    if warped.shape[0] > hay.shape[0] or warped.shape[1] > hay.shape[1]:
+        return None
+    _, max_val, _, max_loc = cv2.minMaxLoc(cv2.matchTemplate(hay, warped, metric))
+    return RotatedMatch(int(max_loc[0]), int(max_loc[1]), warped.shape[1],
+                        warped.shape[0], round(float(max_val), 4),
+                        float(scale), float(angle))
+
+
+def _sweep(template: ImageSource, haystack: Optional[ImageSource],
+           region: Optional[Sequence[int]], scales: Sequence[float],
+           angles: Sequence[float], method: str) -> List[RotatedMatch]:
+    """Correlate every (scale, angle) candidate and return them all."""
+    tmpl = _to_gray(template)
+    hay = _haystack_gray(haystack, region)
+    metric = _method(method)
+    found: List[RotatedMatch] = []
+    for scale in scales:
+        for angle in angles:
+            candidate = _best_at(hay, tmpl, scale, angle, metric)
+            if candidate is not None:
+                found.append(candidate)
+    return found
+
+
+def match_rotated(template: ImageSource, *, haystack: Optional[ImageSource] = None,
+                  region: Optional[Sequence[int]] = None,
+                  scales: Sequence[float] = (1.0,),
+                  angles: Sequence[float] = (0.0,), min_score: float = 0.8,
+                  method: str = "ccoeff_normed") -> Optional[RotatedMatch]:
+    """Return the single best match over the scale x angle sweep, or ``None``.
+
+    Each angle in ``angles`` (degrees) is applied to the template at each scale in
+    ``scales``; the highest-scoring hit at or above ``min_score`` wins, carrying the
+    recovered ``scale`` and ``angle``.
+    """
+    best: Optional[RotatedMatch] = None
+    for candidate in _sweep(template, haystack, region, scales, angles, method):
+        if candidate.score >= min_score and (best is None
+                                             or candidate.score > best.score):
+            best = candidate
+    return best
+
+
+def match_rotated_all(template: ImageSource, *,
+                      haystack: Optional[ImageSource] = None,
+                      region: Optional[Sequence[int]] = None,
+                      scales: Sequence[float] = (1.0,),
+                      angles: Sequence[float] = (0.0,), min_score: float = 0.8,
+                      method: str = "ccoeff_normed", max_results: int = 20,
+                      nms_iou: float = 0.3) -> List[RotatedMatch]:
+    """Return every match >= ``min_score`` over the sweep, overlaps removed (NMS).
+
+    Detections from neighbouring scales / angles that overlap are merged by
+    non-maximum suppression (highest score kept), ordered by score and capped at
+    ``max_results``.
+    """
+    hits = [c for c in _sweep(template, haystack, region, scales, angles, method)
+            if c.score >= min_score]
+    return _nms(hits, float(nms_iou))[:int(max_results)]

--- a/je_auto_control/utils/screen_grid/__init__.py
+++ b/je_auto_control/utils/screen_grid/__init__.py
@@ -1,0 +1,6 @@
+"""Coarse labelled cell grid for VLM grounding (point <-> cell mapping)."""
+from je_auto_control.utils.screen_grid.screen_grid import (
+    GridCell, cell_for_point, grid_cells, point_for_cell,
+)
+
+__all__ = ["GridCell", "cell_for_point", "grid_cells", "point_for_cell"]

--- a/je_auto_control/utils/screen_grid/screen_grid.py
+++ b/je_auto_control/utils/screen_grid/screen_grid.py
@@ -1,0 +1,137 @@
+"""Coarse labelled cell grid over the screen (or a region).
+
+Vision / VLM grounding works far better when the model can refer to a *coarse cell*
+("click cell C3") than to raw pixel coordinates it tends to hallucinate, and a labelled
+grid is the standard way to describe a screenshot to such a model and to map its answer
+back to a point. The framework had no such helper. This lays an ``rows x cols`` grid over
+the screen (or a sub-``region``), labels each cell spreadsheet-style (column letter + row
+number, ``A1`` top-left) and converts both ways: point -> containing cell, and cell ->
+centre point (ready to click).
+
+Pure-stdlib geometry; the only device-bound path is the default that grabs the live screen
+size when neither ``region`` nor ``screen_size`` is given, so every function is fully
+unit-testable by passing an explicit region. Imports no ``PySide6``.
+"""
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+_LABEL_RE = re.compile(r"([A-Za-z]+)(\d+)")
+
+
+@dataclass(frozen=True)
+class GridCell:
+    """One grid cell: spreadsheet ``label``, 0-based ``row`` / ``col`` and bounds."""
+
+    label: str
+    row: int
+    col: int
+    left: int
+    top: int
+    right: int
+    bottom: int
+
+    @property
+    def center(self) -> List[int]:
+        """The cell's centre point ``[x, y]`` (ready to click)."""
+        return [(self.left + self.right) // 2, (self.top + self.bottom) // 2]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the cell as a plain dict including the centre point."""
+        data = asdict(self)
+        data["center"] = self.center
+        return data
+
+
+def _col_label(index: int) -> str:
+    """0-based column index -> spreadsheet letters (0 -> 'A', 26 -> 'AA')."""
+    label, number = "", index + 1
+    while number > 0:
+        number, remainder = divmod(number - 1, 26)
+        label = chr(ord("A") + remainder) + label
+    return label
+
+
+def _col_index(letters: str) -> int:
+    """Spreadsheet letters -> 0-based column index ('A' -> 0, 'AA' -> 26)."""
+    number = 0
+    for char in letters.upper():
+        number = number * 26 + (ord(char) - ord("A") + 1)
+    return number - 1
+
+
+def _bounds(region: Optional[Sequence[int]],
+            screen_size: Optional[Sequence[int]]) -> Tuple[int, int, int, int]:
+    """Resolve the grid rectangle from ``region`` / ``screen_size`` / live screen."""
+    if region is not None:
+        left, top, right, bottom = (int(v) for v in region)
+        return left, top, right, bottom
+    if screen_size is not None:
+        width, height = (int(v) for v in screen_size)
+        return 0, 0, width, height
+    from je_auto_control.wrapper.auto_control_screen import screen_size as _live
+    width, height = _live()
+    return 0, 0, int(width), int(height)
+
+
+def _edges(start: int, length: int, count: int) -> List[int]:
+    """Return ``count`` + 1 evenly spaced integer edges starting at ``start``."""
+    return [start + round(i * length / count) for i in range(count + 1)]
+
+
+def _validate(rows: int, cols: int) -> Tuple[int, int]:
+    """Coerce and check the grid shape; both dimensions must be >= 1."""
+    rows, cols = int(rows), int(cols)
+    if rows < 1 or cols < 1:
+        raise ValueError("rows and cols must both be >= 1")
+    return rows, cols
+
+
+def _make_cell(row: int, col: int, xs: List[int], ys: List[int]) -> GridCell:
+    """Build a ``GridCell`` from a row/col and the precomputed edge arrays."""
+    return GridCell(f"{_col_label(col)}{row + 1}", row, col,
+                    xs[col], ys[row], xs[col + 1], ys[row + 1])
+
+
+def grid_cells(rows: int, cols: int, *, region: Optional[Sequence[int]] = None,
+               screen_size: Optional[Sequence[int]] = None) -> List[GridCell]:
+    """Return every cell of an ``rows`` x ``cols`` grid over the region, row-major."""
+    rows, cols = _validate(rows, cols)
+    left, top, right, bottom = _bounds(region, screen_size)
+    xs = _edges(left, right - left, cols)
+    ys = _edges(top, bottom - top, rows)
+    return [_make_cell(row, col, xs, ys)
+            for row in range(rows) for col in range(cols)]
+
+
+def cell_for_point(x: int, y: int, rows: int, cols: int, *,
+                   region: Optional[Sequence[int]] = None,
+                   screen_size: Optional[Sequence[int]] = None
+                   ) -> Optional[GridCell]:
+    """Return the cell containing ``(x, y)``, or ``None`` if outside the region."""
+    rows, cols = _validate(rows, cols)
+    left, top, right, bottom = _bounds(region, screen_size)
+    if not (left <= x < right and top <= y < bottom):
+        return None
+    col = min(cols - 1, int((x - left) * cols / (right - left)))
+    row = min(rows - 1, int((y - top) * rows / (bottom - top)))
+    xs = _edges(left, right - left, cols)
+    ys = _edges(top, bottom - top, rows)
+    return _make_cell(row, col, xs, ys)
+
+
+def point_for_cell(label: str, rows: int, cols: int, *,
+                   region: Optional[Sequence[int]] = None,
+                   screen_size: Optional[Sequence[int]] = None) -> List[int]:
+    """Return the centre point ``[x, y]`` of the cell named ``label`` (e.g. ``'C3'``)."""
+    rows, cols = _validate(rows, cols)
+    match = _LABEL_RE.fullmatch(label.strip())
+    if not match:
+        raise ValueError(f"invalid cell label: {label!r}")
+    col, row = _col_index(match.group(1)), int(match.group(2)) - 1
+    if not (0 <= col < cols and 0 <= row < rows):
+        raise ValueError(f"cell {label!r} is outside a {rows}x{cols} grid")
+    left, top, right, bottom = _bounds(region, screen_size)
+    xs = _edges(left, right - left, cols)
+    ys = _edges(top, bottom - top, rows)
+    return _make_cell(row, col, xs, ys).center

--- a/je_auto_control/utils/soft_assert/__init__.py
+++ b/je_auto_control/utils/soft_assert/__init__.py
@@ -1,0 +1,4 @@
+"""Soft assertions — accumulate checks and raise the aggregate at block end."""
+from je_auto_control.utils.soft_assert.soft_assert import SoftAssertions
+
+__all__ = ["SoftAssertions"]

--- a/je_auto_control/utils/soft_assert/soft_assert.py
+++ b/je_auto_control/utils/soft_assert/soft_assert.py
@@ -1,0 +1,58 @@
+"""Soft assertions — accumulate checks across a block, raise them all at the end.
+
+``assertion.assert_all`` takes a **pre-built list of spec dicts up front**. There is no
+*scoped accumulator* you sprinkle ``check()`` calls into across interleaved actions and
+that raises everything at once on exit — the JUnit5 ``assertAll`` / Playwright
+``expect.soft`` / AssertJ ``SoftAssertions`` pattern, the standard ergonomics for
+verifying many fields of a form without stopping at the first failure.
+
+Pure-stdlib context manager; imports no ``PySide6``.
+"""
+from typing import Any, List
+
+from je_auto_control.utils.exception.exceptions import AutoControlActionException
+
+
+class SoftAssertions:
+    """A scope that records pass/fail checks and raises the aggregate on exit."""
+
+    def __init__(self, raise_on_exit: bool = True):
+        self._results: List[tuple] = []
+        self._raise_on_exit = bool(raise_on_exit)
+
+    def check(self, condition: Any, message: str = "") -> bool:
+        """Record a truthy/falsy ``condition`` (never raises); return its bool."""
+        ok = bool(condition)
+        self._results.append((ok, str(message) or "assertion failed"))
+        return ok
+
+    def check_equal(self, actual: Any, expected: Any, message: str = "") -> bool:
+        """Record that ``actual == expected``."""
+        return self.check(actual == expected,
+                          message or f"expected {expected!r}, got {actual!r}")
+
+    @property
+    def failures(self) -> List[str]:
+        """The messages of every failed check, in order."""
+        return [message for ok, message in self._results if not ok]
+
+    @property
+    def passed(self) -> int:
+        """How many checks passed."""
+        return sum(1 for ok, _message in self._results if ok)
+
+    def assert_all(self) -> None:
+        """Raise ``AutoControlActionException`` if any recorded check failed."""
+        failures = self.failures
+        if failures:
+            raise AutoControlActionException(
+                f"{len(failures)} soft assertion(s) failed: "
+                + "; ".join(failures))
+
+    def __enter__(self) -> "SoftAssertions":
+        return self
+
+    def __exit__(self, exc_type, _exc, _tb) -> bool:
+        if exc_type is None and self._raise_on_exit:
+            self.assert_all()
+        return False

--- a/je_auto_control/utils/window_geometry/__init__.py
+++ b/je_auto_control/utils/window_geometry/__init__.py
@@ -1,0 +1,6 @@
+"""Window client-area geometry (frame insets, client-to-screen mapping)."""
+from je_auto_control.utils.window_geometry.window_geometry import (
+    client_point, client_to_screen, frame_insets, get_client_rect,
+)
+
+__all__ = ["client_point", "client_to_screen", "frame_insets", "get_client_rect"]

--- a/je_auto_control/utils/window_geometry/window_geometry.py
+++ b/je_auto_control/utils/window_geometry/window_geometry.py
@@ -1,0 +1,75 @@
+"""Window client-area geometry — frame insets and client-relative point mapping.
+
+``window_capture.get_window_geometry`` returns a window's outer bounding box (for
+screenshotting), but there is no *client*-area rect, no frame-inset math, and no
+client→screen point mapping. RPA needs "click at ``(x, y)`` *inside* this window's
+client area regardless of title-bar height / borders" — the building block for
+window-relative clicking. This adds the client rect, the pure frame-inset and
+client-to-screen helpers, and a one-call ``client_point``.
+
+``frame_insets`` / ``client_to_screen`` are pure geometry (headless-testable); only
+``get_client_rect``'s default reader touches Win32 (``GetClientRect`` +
+``ClientToScreen``), and it is injectable. Imports no ``PySide6``.
+"""
+import sys
+from typing import Callable, Dict, Optional, Tuple
+
+Rect = Tuple[int, int, int, int]
+RectReader = Callable[[str], Optional[Rect]]
+
+
+def frame_insets(window_rect: Rect, client_rect: Rect) -> Dict[str, int]:
+    """Return the border / title-bar thickness as ``{left, top, right, bottom}``.
+
+    Both rects are ``(x, y, width, height)`` in screen coordinates; the client rect is
+    inset within the window rect by the frame.
+    """
+    wx, wy, ww, wh = (int(v) for v in window_rect[:4])
+    cx, cy, cw, ch = (int(v) for v in client_rect[:4])
+    return {"left": cx - wx, "top": cy - wy,
+            "right": (wx + ww) - (cx + cw), "bottom": (wy + wh) - (cy + ch)}
+
+
+def client_to_screen(client_rect: Rect, x: int, y: int) -> Tuple[int, int]:
+    """Map a client-area-local point to absolute screen coordinates."""
+    return (int(client_rect[0]) + int(x), int(client_rect[1]) + int(y))
+
+
+def _default_client_reader(title: str) -> Optional[Rect]:
+    """Read a window's client rect in screen coordinates (Win32 only)."""
+    if not sys.platform.startswith("win"):
+        return None
+    from je_auto_control.wrapper.auto_control_window import find_window
+    hit = find_window(title)
+    if hit is None:
+        return None
+    import ctypes
+    from ctypes import wintypes
+    hwnd = int(hit[0])
+    rect = wintypes.RECT()
+    if not ctypes.windll.user32.GetClientRect(hwnd, ctypes.byref(rect)):
+        return None
+    origin = wintypes.POINT(0, 0)
+    ctypes.windll.user32.ClientToScreen(hwnd, ctypes.byref(origin))
+    return (origin.x, origin.y, rect.right - rect.left, rect.bottom - rect.top)
+
+
+def get_client_rect(title: str, *,
+                    reader: Optional[RectReader] = None) -> Optional[Rect]:
+    """Return ``(x, y, width, height)`` of a window's client area (or ``None``).
+
+    The origin is in screen coordinates. ``reader`` is injectable for tests; the
+    default uses Win32 and returns ``None`` on other platforms.
+    """
+    return (reader or _default_client_reader)(title)
+
+
+def client_point(title: str, x: int, y: int, *,
+                 reader: Optional[RectReader] = None) -> Optional[Tuple[int, int]]:
+    """Return the screen point for a client-area-local ``(x, y)`` (or ``None``).
+
+    Lets you click at a position *inside* the window regardless of its title-bar /
+    border thickness.
+    """
+    rect = get_client_rect(title, reader=reader)
+    return client_to_screen(rect, x, y) if rect is not None else None

--- a/je_auto_control/utils/window_zorder/__init__.py
+++ b/je_auto_control/utils/window_zorder/__init__.py
@@ -1,0 +1,7 @@
+"""Window z-order control (topmost / bring-to-front / send-to-back)."""
+from je_auto_control.utils.window_zorder.window_zorder import (
+    available_actions, bring_to_front, plan_zorder, send_to_back, set_topmost,
+)
+
+__all__ = ["available_actions", "bring_to_front", "plan_zorder", "send_to_back",
+           "set_topmost"]

--- a/je_auto_control/utils/window_zorder/window_zorder.py
+++ b/je_auto_control/utils/window_zorder/window_zorder.py
@@ -1,0 +1,69 @@
+"""Window z-order control — always-on-top / topmost, bring-to-front, send-to-back.
+
+``windows_window_manage.set_window_position(hwnd, position)`` exists at the raw Win32
+layer but is **not** exported in the package facade, has no title-based wrapper, and no
+topmost / not-topmost semantics — and there is no ``always_on_top`` anywhere outside
+GUI overlay code. This adds the standard RPA z-order primitive: a pure ``plan_zorder``
+that maps an action to the ``SetWindowPos`` insert-after constant, plus title-based
+``set_topmost`` / ``bring_to_front`` / ``send_to_back`` over an injectable driver (the
+same seam pattern as ``snap_window``).
+
+The planning is pure and headless-testable; only the default driver touches Win32
+(returning ``False`` on other platforms). Imports no ``PySide6``.
+"""
+import sys
+from typing import Any, Callable, Dict
+
+ZOrderDriver = Callable[[str, str], bool]
+
+# action -> SetWindowPos hwndInsertAfter constant
+_ACTIONS = {"top": 0, "bottom": 1, "topmost": -1, "notopmost": -2}
+
+
+def available_actions() -> list:
+    """Return the supported z-order action names."""
+    return list(_ACTIONS)
+
+
+def plan_zorder(action: str) -> Dict[str, Any]:
+    """Return the ``SetWindowPos`` descriptor for a z-order ``action``.
+
+    ``action`` is one of ``top`` / ``bottom`` / ``topmost`` / ``notopmost``; the
+    result carries the ``insert_after`` HWND constant and the move/size-preserving
+    flags. Raises ``ValueError`` for an unknown action.
+    """
+    if action not in _ACTIONS:
+        raise ValueError(f"unknown z-order action: {action!r}")
+    return {"action": action, "insert_after": _ACTIONS[action],
+            "flags": ["SWP_NOMOVE", "SWP_NOSIZE"]}
+
+
+def _default_driver(title: str, action: str) -> bool:
+    """Apply a z-order action to the window matching ``title`` (Win32 only)."""
+    if not sys.platform.startswith("win"):
+        return False
+    from je_auto_control.wrapper.auto_control_window import find_window
+    hit = find_window(title)
+    if hit is None:
+        return False
+    from je_auto_control.windows.window import windows_window_manage as wm
+    wm.set_window_position(int(hit[0]), plan_zorder(action)["insert_after"])
+    return True
+
+
+def set_topmost(title: str, on: bool = True, *,
+                driver: Callable[[str, str], bool] = None) -> bool:
+    """Pin the window matching ``title`` always-on-top (or release it when ``on`` is False)."""
+    return (driver or _default_driver)(title, "topmost" if on else "notopmost")
+
+
+def bring_to_front(title: str, *,
+                   driver: Callable[[str, str], bool] = None) -> bool:
+    """Raise the window matching ``title`` to the top of the z-order."""
+    return (driver or _default_driver)(title, "top")
+
+
+def send_to_back(title: str, *,
+                 driver: Callable[[str, str], bool] = None) -> bool:
+    """Send the window matching ``title`` to the bottom of the z-order."""
+    return (driver or _default_driver)(title, "bottom")

--- a/test/unit_test/headless/test_action_grounding_batch.py
+++ b/test/unit_test/headless/test_action_grounding_batch.py
@@ -1,0 +1,62 @@
+"""Headless tests for the pre-action grounding guard. No Qt."""
+import je_auto_control as ac
+from je_auto_control.utils.action_grounding import (
+    in_bounds, snap_to_element, validate_action,
+)
+
+_ELEMENTS = [{"x": 100, "y": 100, "width": 40, "height": 20},
+             {"x": 300, "y": 200, "width": 60, "height": 30}]
+
+
+def test_in_bounds():
+    assert in_bounds(50, 50, (1920, 1080)) is True
+    assert in_bounds(9999, 5, (1920, 1080)) is False
+    assert in_bounds(-1, 5, (1920, 1080)) is False
+
+
+def test_snap_inside_and_near_and_far():
+    assert snap_to_element(110, 108, _ELEMENTS) == [120, 110]      # inside el1
+    assert snap_to_element(122, 112, _ELEMENTS, max_dist=8) == [120, 110]
+    assert snap_to_element(500, 500, _ELEMENTS, max_dist=8) is None
+
+
+def test_validate_rejects_out_of_bounds():
+    result = validate_action({"type": "click", "x": 9999, "y": 5},
+                             screen_size=(1920, 1080))
+    assert result["ok"] is False and result["reason"] == "out of bounds"
+
+
+def test_validate_snaps_near_miss():
+    result = validate_action({"type": "click", "x": 118, "y": 109},
+                             screen_size=(1920, 1080), targets=_ELEMENTS)
+    assert result["ok"] is True and result["snapped"] == [120, 110]
+
+
+def test_validate_in_bounds_no_snap():
+    result = validate_action({"type": "click", "x": 500, "y": 500},
+                             screen_size=(1920, 1080), targets=_ELEMENTS)
+    assert result["ok"] is True and result["reason"] == "in bounds"
+    assert result["snapped"] is None
+
+
+def test_validate_no_coordinate_passes():
+    result = validate_action({"type": "type", "text": "hi"},
+                             screen_size=(1920, 1080))
+    assert result["ok"] is True and result["reason"] == "no coordinate"
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    assert "AC_validate_action" in set(ac.executor.known_commands())
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert "ac_validate_action" in names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert "AC_validate_action" in specs
+
+
+def test_facade_exports():
+    for attr in ("in_bounds", "snap_to_element", "validate_action"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_agent_replay_batch.py
+++ b/test/unit_test/headless/test_agent_replay_batch.py
@@ -1,0 +1,58 @@
+"""Headless tests for the agent-trajectory trace. No Qt; runner is injected."""
+import je_auto_control as ac
+from je_auto_control.utils.agent_replay import (
+    from_jsonl, record_step, replay_trace, to_jsonl,
+)
+
+
+def _trace():
+    trace = []
+    record_step(trace, "obs0", ["AC_click_mouse", {"x": 1, "y": 2}])
+    record_step(trace, "obs1", ["AC_write", {"write_string": "hi"}],
+                result={"ok": True})
+    return trace
+
+
+def test_record_step_indexes_and_keeps_result():
+    trace = _trace()
+    assert [s["step"] for s in trace] == [0, 1]
+    assert trace[0]["observation"] == "obs0"
+    assert "result" not in trace[0] and trace[1]["result"] == {"ok": True}
+
+
+def test_jsonl_round_trip():
+    trace = _trace()
+    text = to_jsonl(trace)
+    assert len(text.splitlines()) == 2
+    assert from_jsonl(text) == trace
+
+
+def test_from_jsonl_skips_blank_lines():
+    assert from_jsonl('{"step": 0}\n\n  \n{"step": 1}\n') == [{"step": 0},
+                                                             {"step": 1}]
+
+
+def test_replay_runs_each_action_in_order():
+    calls = []
+    results = replay_trace(_trace(), lambda action: calls.append(action[0])
+                           or f"ran:{action[0]}")
+    assert calls == ["AC_click_mouse", "AC_write"]
+    assert [(r["step"], r["result"]) for r in results] == [
+        (0, "ran:AC_click_mouse"), (1, "ran:AC_write")]
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    assert "AC_replay_trace" in set(ac.executor.known_commands())
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert "ac_replay_trace" in names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert "AC_replay_trace" in specs
+
+
+def test_facade_exports():
+    for attr in ("record_step", "to_jsonl", "from_jsonl", "replay_trace"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_barcode_batch.py
+++ b/test/unit_test/headless/test_barcode_batch.py
@@ -1,0 +1,52 @@
+"""Headless tests for 1-D barcode decoding. No Qt; decoder is injected."""
+import pytest
+
+import je_auto_control as ac
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("cv2")
+
+from je_auto_control.utils.barcode import read_barcodes   # noqa: E402
+
+
+def _image():
+    return np.full((40, 120), 255, dtype=np.uint8)
+
+
+def test_injected_decoder_is_used():
+    rows = [{"text": "012345678905", "type": "EAN_13",
+             "points": [[0, 0], [100, 0], [100, 30], [0, 30]]}]
+    result = read_barcodes(_image(), decoder=lambda image: rows)
+    assert result == rows
+
+
+def test_decoder_receives_the_image():
+    seen = {}
+
+    def decoder(image):
+        seen["shape"] = getattr(image, "shape", None)
+        return []
+
+    read_barcodes(_image(), decoder=decoder)
+    assert seen["shape"] == (40, 120)
+
+
+def test_default_decoder_blank_image_is_empty():
+    # a blank image has no barcodes (graceful, regardless of cv2.barcode presence)
+    assert read_barcodes(_image()) == []
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    assert "AC_read_barcodes" in set(ac.executor.known_commands())
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert "ac_read_barcodes" in names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert "AC_read_barcodes" in specs
+
+
+def test_facade_exports():
+    assert hasattr(ac, "read_barcodes") and "read_barcodes" in ac.__all__

--- a/test/unit_test/headless/test_clipboard_files_batch.py
+++ b/test/unit_test/headless/test_clipboard_files_batch.py
@@ -1,0 +1,64 @@
+"""Headless tests for CF_HDROP DROPFILES packing (pure byte math; Win32 skipped)."""
+import struct
+
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.clipboard_files import build_dropfiles, parse_dropfiles
+
+
+def test_round_trip_wide():
+    paths = ["C:\\a\\one.txt", "C:\\b\\twö.png"]  # non-ASCII to exercise UTF-16
+    blob = build_dropfiles(paths, point=(12, 34))
+    parsed = parse_dropfiles(blob)
+    assert parsed["paths"] == paths
+    assert parsed["point"] == [12, 34]
+    assert parsed["wide"] is True
+    assert parsed["non_client"] is False
+
+
+def test_header_layout_and_double_null():
+    blob = build_dropfiles(["a.txt"])
+    p_files, x, y, f_nc, f_wide = struct.unpack("<5I", blob[:20])
+    assert p_files == 20  # list begins right after the 20-byte header
+    assert (x, y, f_nc, f_wide) == (0, 0, 0, 1)
+    # wide list ends with two UTF-16 nulls (path-null + list-null)
+    assert blob.endswith(b"\x00\x00\x00\x00")
+
+
+def test_non_wide_uses_single_byte():
+    blob = build_dropfiles(["ab.txt"], wide=False)
+    assert struct.unpack("<5I", blob[:20])[4] == 0
+    parsed = parse_dropfiles(blob)
+    assert parsed["paths"] == ["ab.txt"] and parsed["wide"] is False
+
+
+def test_point_and_non_client_flags():
+    parsed = parse_dropfiles(build_dropfiles(["x"], point=(5, 9), non_client=True))
+    assert parsed["point"] == [5, 9] and parsed["non_client"] is True
+
+
+def test_empty_paths_and_short_data_raise():
+    with pytest.raises(ValueError):
+        build_dropfiles([])
+    with pytest.raises(ValueError):
+        parse_dropfiles(b"\x00\x00")
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_set_clipboard_files", "AC_get_clipboard_files"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_set_clipboard_files", "ac_get_clipboard_files"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_set_clipboard_files", "AC_get_clipboard_files"} <= specs
+
+
+def test_facade_exports():
+    for name in ("build_dropfiles", "parse_dropfiles",
+                 "set_clipboard_files", "get_clipboard_files"):
+        assert hasattr(ac, name) and name in ac.__all__

--- a/test/unit_test/headless/test_cua_action_batch.py
+++ b/test/unit_test/headless/test_cua_action_batch.py
@@ -1,0 +1,84 @@
+"""Headless tests for canonical computer-use action mapping. No Qt."""
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.cua_action import (
+    canonical_action, from_anthropic, from_openai_cua, to_ac_command,
+)
+from je_auto_control.utils.exception.exceptions import AutoControlActionException
+
+
+def test_canonical_action_drops_none():
+    assert canonical_action("click", x=1, y=2, text=None) == {"type": "click",
+                                                              "x": 1, "y": 2}
+
+
+def test_from_anthropic_click_key_scroll():
+    assert from_anthropic({"action": "left_click", "coordinate": [100, 200]}) == {
+        "type": "click", "x": 100, "y": 200}
+    assert from_anthropic({"action": "key", "text": "ctrl+s"}) == {
+        "type": "key", "text": "ctrl+s"}
+    scroll = from_anthropic({"action": "scroll", "coordinate": [10, 20],
+                             "scroll_direction": "down", "scroll_amount": 3})
+    assert scroll["type"] == "scroll" and scroll["amount"] == 3
+
+
+def test_from_openai_click_button_and_keypress():
+    assert from_openai_cua({"type": "click", "x": 5, "y": 6,
+                            "button": "right"})["type"] == "right_click"
+    assert from_openai_cua({"type": "keypress", "keys": ["ctrl", "c"]}) == {
+        "type": "key", "text": "ctrl+c"}
+
+
+def test_to_ac_command_click_key_scroll():
+    assert to_ac_command({"type": "click", "x": 100, "y": 200}) == [
+        "AC_click_mouse", {"mouse_keycode": "mouse_left", "x": 100, "y": 200}]
+    assert to_ac_command({"type": "key", "text": "ctrl+s"}) == [
+        "AC_hotkey", {"key_code_list": ["ctrl", "s"]}]
+    assert to_ac_command({"type": "type", "text": "hi"}) == [
+        "AC_write", {"write_string": "hi"}]
+    assert to_ac_command({"type": "scroll", "x": 1, "y": 2, "scroll_y": 120}) == [
+        "AC_mouse_scroll", {"scroll_value": -120, "x": 1, "y": 2}]
+
+
+def test_to_ac_command_applies_scale():
+    assert to_ac_command({"type": "move", "x": 50, "y": 60},
+                         scale=lambda x, y: (x * 2, y * 2)) == [
+        "AC_set_mouse_position", {"x": 100, "y": 120}]
+
+
+def test_to_ac_command_unsupported_raises():
+    with pytest.raises(AutoControlActionException):
+        to_ac_command({"type": "wait"})
+
+
+def test_round_trip_anthropic_to_ac():
+    canonical = from_anthropic({"action": "right_click", "coordinate": [7, 8]})
+    assert to_ac_command(canonical) == [
+        "AC_click_mouse", {"mouse_keycode": "mouse_right", "x": 7, "y": 8}]
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    assert "AC_cua_command" in set(ac.executor.known_commands())
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert "ac_cua_command" in names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert "AC_cua_command" in specs
+
+
+def test_executor_normalizes_and_maps():
+    from je_auto_control.utils.executor.action_executor import _cua_command
+    result = _cua_command({"action": "left_click", "coordinate": [3, 4]},
+                          source="anthropic")
+    assert result["command"] == ["AC_click_mouse",
+                                 {"mouse_keycode": "mouse_left", "x": 3, "y": 4}]
+
+
+def test_facade_exports():
+    for attr in ("canonical_action", "from_anthropic", "from_openai_cua",
+                 "to_ac_command"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_element_diff_batch.py
+++ b/test/unit_test/headless/test_element_diff_batch.py
@@ -1,0 +1,64 @@
+"""Headless tests for geometry-aware element diff / stable IDs. No Qt."""
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.element_diff import assign_stable_ids, match_elements
+
+
+def _b(x, y, w, h, **extra):
+    return dict(x=x, y=y, width=w, height=h, **extra)
+
+
+def test_match_pairs_added_removed():
+    before = [_b(10, 10, 40, 20, name="Save"), _b(100, 10, 40, 20, name="Delete")]
+    after = [_b(12, 11, 40, 20, name="Save"), _b(300, 300, 50, 25, name="New")]
+    result = match_elements(before, after)
+    assert len(result["matched"]) == 1
+    assert result["matched"][0]["before"]["name"] == "Save"
+    assert [a["name"] for a in result["added"]] == ["New"]
+    assert [r["name"] for r in result["removed"]] == ["Delete"]
+
+
+def test_match_iou_recorded():
+    pair = match_elements([_b(0, 0, 10, 10)], [_b(0, 0, 10, 10)])["matched"][0]
+    assert pair["iou"] == pytest.approx(1.0)
+
+
+def test_no_match_below_threshold():
+    result = match_elements([_b(0, 0, 10, 10)], [_b(50, 0, 10, 10)],
+                            iou_threshold=0.5)
+    assert result["matched"] == [] and len(result["added"]) == 1
+    assert len(result["removed"]) == 1
+
+
+def test_assign_ids_fresh_without_prior():
+    ids = [e["id"] for e in assign_stable_ids([_b(0, 0, 5, 5), _b(9, 9, 5, 5)])]
+    assert ids == [0, 1]
+
+
+def test_assign_ids_carry_from_prior():
+    prior = assign_stable_ids([_b(10, 10, 40, 20, name="Save"),
+                               _b(100, 10, 40, 20, name="Delete")])
+    nxt = assign_stable_ids([_b(12, 11, 40, 20, name="Save"),
+                             _b(300, 300, 50, 25, name="New")], prior=prior)
+    by_name = {e["name"]: e["id"] for e in nxt}
+    assert by_name["Save"] == 0          # carried despite the 2px move
+    assert by_name["New"] == 2           # fresh id beyond the prior max (1)
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_match_elements", "AC_assign_stable_ids"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_match_elements", "ac_assign_stable_ids"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_match_elements", "AC_assign_stable_ids"} <= specs
+
+
+def test_facade_exports():
+    for attr in ("match_elements", "assign_stable_ids"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_element_scoring_batch.py
+++ b/test/unit_test/headless/test_element_scoring_batch.py
@@ -1,0 +1,80 @@
+"""Headless tests for weighted candidate scoring. No Qt."""
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.element_scoring import (
+    ScoredCandidate, best_candidate, score_candidates,
+)
+
+
+def _candidates():
+    return [
+        {"role": "button", "name": "Save", "x": 10, "y": 10, "width": 40,
+         "height": 20, "enabled": True},
+        {"role": "button", "name": "Save As", "x": 100, "y": 10, "width": 60,
+         "height": 20, "enabled": True},
+        {"role": "link", "name": "Save", "x": 10, "y": 200, "width": 40,
+         "height": 20, "enabled": False},
+    ]
+
+
+def test_exact_button_near_anchor_ranks_first():
+    ranked = score_candidates(_candidates(), want_role="button", want_name="Save",
+                              anchor=(20, 15))
+    assert ranked[0].element["name"] == "Save"
+    assert ranked[0].element["role"] == "button"
+    assert ranked[0].score > ranked[1].score > ranked[2].score
+
+
+def test_matched_on_breakdown():
+    top = score_candidates(_candidates(), want_role="button",
+                           want_name="Save")[0]
+    assert top.matched_on["role"] == pytest.approx(1.0)
+    assert top.matched_on["name"] == pytest.approx(1.0)
+    assert top.matched_on["enabled"] == pytest.approx(1.0)
+
+
+def test_disabled_wrong_role_ranks_last():
+    ranked = score_candidates(_candidates(), want_role="button", want_name="Save")
+    assert ranked[-1].element["role"] == "link"      # disabled + wrong role
+
+
+def test_injected_similarity_is_used():
+    calls = []
+
+    def sim(a, b):
+        calls.append((a, b))
+        return 1.0 if a == b else 0.0
+
+    score_candidates(_candidates(), want_name="Save", name_similarity=sim,
+                     prefer_enabled=False)
+    assert calls and all(call[0] == "Save" for call in calls)
+
+
+def test_best_candidate_and_empty():
+    assert best_candidate(_candidates(), want_name="Save").element["name"] == "Save"
+    assert best_candidate([], want_name="x") is None
+
+
+def test_scored_candidate_to_dict():
+    top = score_candidates(_candidates(), want_role="button")[0]
+    assert isinstance(top, ScoredCandidate)
+    assert set(top.to_dict()) == {"element", "score", "matched_on"}
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_score_candidates", "AC_best_candidate"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_score_candidates", "ac_best_candidate"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_score_candidates", "AC_best_candidate"} <= specs
+
+
+def test_facade_exports():
+    for attr in ("score_candidates", "best_candidate", "ScoredCandidate"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_img_histogram_batch.py
+++ b/test/unit_test/headless/test_img_histogram_batch.py
@@ -1,0 +1,80 @@
+"""Headless tests for colour-histogram fingerprint / change detection. No Qt."""
+import pytest
+
+import je_auto_control as ac
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("cv2")
+
+from je_auto_control.utils.img_histogram import (   # noqa: E402
+    compare_histograms, histogram_changed, image_histogram,
+)
+
+
+def _palette_a():
+    img = np.zeros((60, 80, 3), dtype=np.uint8)
+    img[:, :40] = (200, 0, 0)            # red | green
+    img[:, 40:] = (0, 200, 0)
+    return img
+
+
+def _palette_b():
+    img = np.zeros((60, 80, 3), dtype=np.uint8)
+    img[:, :40] = (0, 0, 200)            # blue | yellow (same shapes, new palette)
+    img[:, 40:] = (200, 200, 0)
+    return img
+
+
+def test_histogram_length_per_channel():
+    assert len(image_histogram(_palette_a(), bins=32, space="hsv")) == 96
+    assert len(image_histogram(_palette_a(), bins=16, space="gray")) == 16
+
+
+def test_identical_correlation_is_one():
+    hist = image_histogram(_palette_a())
+    assert compare_histograms(hist, hist) == pytest.approx(1.0)
+
+
+def test_different_palette_lowers_correlation():
+    score = compare_histograms(image_histogram(_palette_a()),
+                               image_histogram(_palette_b()))
+    assert score < 0.9
+
+
+def test_changed_detects_palette_shift():
+    assert histogram_changed(_palette_a(), _palette_b()) is True
+    assert histogram_changed(_palette_a(), _palette_a().copy()) is False
+
+
+def test_distance_method_semantics():
+    score = compare_histograms(image_histogram(_palette_a()),
+                               image_histogram(_palette_b()),
+                               method="bhattacharyya")
+    assert score > 0.3
+    assert histogram_changed(_palette_a(), _palette_b(), method="bhattacharyya",
+                             threshold=0.3) is True
+
+
+def test_unknown_space_and_method_raise():
+    with pytest.raises(ValueError):
+        image_histogram(_palette_a(), space="cmyk")
+    with pytest.raises(ValueError):
+        compare_histograms([1.0], [1.0], method="cosine")
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_image_histogram", "AC_histogram_changed"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_image_histogram", "ac_histogram_changed"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_image_histogram", "AC_histogram_changed"} <= specs
+
+
+def test_facade_exports():
+    for attr in ("image_histogram", "compare_histograms", "histogram_changed"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_motion_regions_batch.py
+++ b/test/unit_test/headless/test_motion_regions_batch.py
@@ -1,0 +1,70 @@
+"""Headless tests for localized motion / activity detection. No Qt."""
+import pytest
+
+import je_auto_control as ac
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("cv2")
+
+from je_auto_control.utils.motion_regions import (   # noqa: E402
+    activity_score, changed_regions, has_motion,
+)
+
+
+def _before():
+    return np.full((120, 160), 100, dtype=np.uint8)
+
+
+def _after_block():
+    after = _before()
+    after[40:70, 50:90] = 255            # a 40x30 region lights up
+    return after
+
+
+def test_changed_regions_locates_the_block():
+    regions = changed_regions(_before(), _after_block(), min_area=50)
+    assert len(regions) == 1
+    box = regions[0]
+    assert 30 <= box["x"] <= 55 and 25 <= box["y"] <= 45   # ~the (50,40) block
+
+
+def test_has_motion_true_and_false():
+    assert has_motion(_before(), _after_block()) is True
+    assert has_motion(_before(), _before().copy()) is False
+
+
+def test_activity_score_fraction():
+    # 40*30 changed of 120*160 = 0.0625
+    assert activity_score(_before(), _after_block()) == pytest.approx(0.0625,
+                                                                      abs=0.01)
+    assert activity_score(_before(), _before().copy()) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_min_area_filters_specks():
+    after = _before()
+    after[10:13, 10:13] = 255            # tiny 3x3 speck
+    assert changed_regions(_before(), after, min_area=500) == []
+
+
+def test_size_mismatch_raises():
+    small = np.zeros((40, 40), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        changed_regions(_before(), small)
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_changed_regions", "AC_has_motion"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_changed_regions", "ac_has_motion"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_changed_regions", "AC_has_motion"} <= specs
+
+
+def test_facade_exports():
+    for attr in ("changed_regions", "has_motion", "activity_score"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_observation_batch.py
+++ b/test/unit_test/headless/test_observation_batch.py
@@ -1,0 +1,65 @@
+"""Headless tests for the indexed a11y text observation. No Qt."""
+import je_auto_control as ac
+from je_auto_control.utils.observation import (
+    flatten_tree, observation_index, serialize_observation,
+)
+
+
+def _tree():
+    return [{"role": "window", "name": "App", "children": [
+        {"role": "button", "name": "Save", "x": 10, "y": 10, "width": 40,
+         "height": 20},
+        {"role": "textbox", "name": "Search", "x": 100, "y": 10, "width": 80,
+         "height": 20},
+        {"role": "label", "name": "static", "x": 10, "y": 50, "width": 60,
+         "height": 20},
+        {"role": "button", "name": "Offscreen", "x": 10, "y": 5000, "width": 40,
+         "height": 20},
+    ]}]
+
+
+def test_flatten_keeps_only_interactive():
+    roles = [(e["role"], e["name"]) for e in flatten_tree(_tree())]
+    assert ("button", "Save") in roles and ("textbox", "Search") in roles
+    assert ("label", "static") not in roles      # non-interactive dropped
+    assert ("window", "App") not in roles
+
+
+def test_flatten_all_when_not_interactive_only():
+    roles = {e["role"] for e in flatten_tree(_tree(), interactive_only=False)}
+    assert {"window", "button", "textbox", "label"} <= roles
+
+
+def test_observation_index_clips_viewport_and_indexes():
+    indexed = observation_index(_tree(), viewport=(0, 0, 1920, 1080))
+    assert [(e["index"], e["name"]) for e in indexed] == [(0, "Save"),
+                                                          (1, "Search")]
+    # the y=5000 button is clipped out
+
+
+def test_observation_index_cap():
+    assert len(observation_index(_tree(), max_elements=1)) == 1
+
+
+def test_serialize_observation_lines():
+    text = serialize_observation(_tree(), viewport=(0, 0, 1920, 1080))
+    assert text.splitlines() == ['[0] button "Save" @(30,20)',
+                                 '[1] textbox "Search" @(140,20)']
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_serialize_observation", "AC_observation_index"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_serialize_observation", "ac_observation_index"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_serialize_observation", "AC_observation_index"} <= specs
+
+
+def test_facade_exports():
+    for attr in ("flatten_tree", "observation_index", "serialize_observation"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_perceptual_diff_batch.py
+++ b/test/unit_test/headless/test_perceptual_diff_batch.py
@@ -1,0 +1,75 @@
+"""Headless tests for perceptual (YIQ) image diff. No Qt."""
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.exception.exceptions import AutoControlActionException
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("cv2")
+
+from je_auto_control.utils.perceptual_diff import (   # noqa: E402
+    PerceptualDiffResult, assert_perceptual, perceptual_diff,
+)
+
+
+def _base():
+    return np.full((100, 120, 3), 128, dtype=np.uint8)
+
+
+def _block():
+    img = _base()
+    img[30:60, 40:80] = (255, 0, 0)      # 40x30 solid change
+    return img
+
+
+def test_identical_has_no_diff():
+    result = perceptual_diff(_base(), _base().copy())
+    assert result.diff_pixels == 0 and result.diff_ratio == pytest.approx(0.0)
+
+
+def test_solid_block_is_counted():
+    result = perceptual_diff(_base(), _block())
+    assert isinstance(result, PerceptualDiffResult)
+    assert result.diff_pixels == 1200 and len(result.regions) == 1
+    assert result.diff_ratio == pytest.approx(0.1)
+
+
+def test_thin_fringe_suppressed_as_antialiasing():
+    fringe = _base()
+    fringe[:, 60:61] = (200, 200, 200)   # 1px-wide vertical edge difference
+    assert perceptual_diff(_base(), fringe, include_aa=False).diff_pixels == 0
+    assert perceptual_diff(_base(), fringe, include_aa=True).diff_pixels == 100
+
+
+def test_threshold_tolerates_small_colour_shift():
+    shifted = _base().copy()
+    shifted[:, :] = (132, 132, 132)      # small uniform shift
+    assert perceptual_diff(_base(), shifted, threshold=0.2).diff_pixels == 0
+
+
+def test_size_mismatch_raises():
+    with pytest.raises(ValueError):
+        perceptual_diff(_base(), np.zeros((10, 10, 3), dtype=np.uint8))
+
+
+def test_assert_perceptual_raises_over_budget():
+    with pytest.raises(AutoControlActionException):
+        assert_perceptual(_base(), _block(), max_diff_ratio=0.0)
+    assert assert_perceptual(_base(), _base().copy()).diff_pixels == 0
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    assert "AC_perceptual_diff" in set(ac.executor.known_commands())
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert "ac_perceptual_diff" in names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert "AC_perceptual_diff" in specs
+
+
+def test_facade_exports():
+    for attr in ("perceptual_diff", "assert_perceptual", "PerceptualDiffResult"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_rotated_match_batch.py
+++ b/test/unit_test/headless/test_rotated_match_batch.py
@@ -1,0 +1,90 @@
+"""Headless tests for rotation/scale-tolerant matching on synthetic arrays."""
+import pytest
+
+import je_auto_control as ac
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("cv2")
+
+from je_auto_control.utils.rotated_match import (  # noqa: E402
+    match_rotated, match_rotated_all, scale_space,
+)
+from je_auto_control.utils.rotated_match.rotated_match import _rotate  # noqa: E402
+
+
+def _template():
+    # asymmetric (left half bright) so the best-correlating angle is unambiguous
+    tmpl = np.zeros((24, 24), dtype=np.uint8)
+    tmpl[:, :12] = 200
+    return tmpl
+
+
+def _haystack_with(patch, top, left):
+    hay = np.zeros((140, 160), dtype=np.uint8)
+    height, width = patch.shape[:2]
+    hay[top:top + height, left:left + width] = patch
+    return hay
+
+
+def test_finds_rotated_template_and_recovers_angle():
+    tmpl = _template()
+    rotated = _rotate(tmpl, 30.0)
+    hay = _haystack_with(rotated, top=50, left=40)
+    best = match_rotated(tmpl, haystack=hay, angles=(0.0, 15.0, 30.0, 45.0),
+                         min_score=0.9)
+    assert best is not None
+    assert abs(best.angle - 30.0) < 1e-9
+    assert best.score >= 0.99
+    assert abs(best.x - 40) <= 1 and abs(best.y - 50) <= 1
+
+
+def test_zero_angle_locates_unrotated_patch():
+    tmpl = _template()
+    hay = _haystack_with(tmpl, top=20, left=30)
+    best = match_rotated(tmpl, haystack=hay, angles=(0.0,), min_score=0.9)
+    assert best is not None
+    assert abs(best.angle) < 1e-9
+    assert best.center == [30 + 12, 20 + 12]
+
+
+def test_no_match_returns_none():
+    tmpl = _template()
+    hay = np.zeros((140, 160), dtype=np.uint8)  # template absent
+    assert match_rotated(tmpl, haystack=hay, angles=(0.0, 30.0),
+                         min_score=0.95) is None
+
+
+def test_match_all_dedupes_overlaps():
+    tmpl = _template()
+    rotated = _rotate(tmpl, 30.0)
+    hay = _haystack_with(rotated, top=50, left=40)
+    # neighbouring angles overlap on the same spot; NMS collapses them to one
+    hits = match_rotated_all(tmpl, haystack=hay, angles=(28.0, 30.0, 32.0),
+                             min_score=0.85, nms_iou=0.3)
+    assert len(hits) == 1
+    assert abs(hits[0].angle - 30.0) < 1e-9
+
+
+def test_scale_space_is_evenly_spaced_inclusive():
+    scales = scale_space(0.8, 1.2, 3)
+    assert len(scales) == 3
+    assert abs(scales[0] - 0.8) < 1e-9
+    assert abs(scales[1] - 1.0) < 1e-9
+    assert abs(scales[2] - 1.2) < 1e-9
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    assert "AC_match_rotated" in set(ac.executor.known_commands())
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert "ac_match_rotated" in names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert "AC_match_rotated" in specs
+
+
+def test_facade_exports():
+    assert hasattr(ac, "match_rotated") and "match_rotated" in ac.__all__
+    assert hasattr(ac, "match_rotated_all")

--- a/test/unit_test/headless/test_screen_grid_batch.py
+++ b/test/unit_test/headless/test_screen_grid_batch.py
@@ -1,0 +1,81 @@
+"""Headless tests for the coarse labelled screen grid (pure stdlib)."""
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.screen_grid import (
+    cell_for_point, grid_cells, point_for_cell,
+)
+
+REGION = [0, 0, 400, 200]
+
+
+def test_grid_cells_cover_region_row_major():
+    cells = grid_cells(2, 4, region=REGION)
+    assert len(cells) == 8
+    assert [c.label for c in cells[:4]] == ["A1", "B1", "C1", "D1"]
+    assert cells[0].left == 0 and cells[0].right == 100
+    assert cells[-1].label == "D2" and cells[-1].right == 400
+    assert cells[-1].bottom == 200
+
+
+def test_cell_for_point_inside():
+    cell = cell_for_point(150, 50, 2, 4, region=REGION)
+    assert cell is not None
+    assert cell.label == "B1"  # x 150 -> col 1, y 50 -> row 0
+
+
+def test_cell_for_point_outside_is_none():
+    assert cell_for_point(500, 50, 2, 4, region=REGION) is None
+    assert cell_for_point(10, -1, 2, 4, region=REGION) is None
+
+
+def test_point_for_cell_returns_centre():
+    # C1 is the third column of four over width 400 -> x in [200,300), centre 250
+    assert point_for_cell("C1", 2, 4, region=REGION) == [250, 50]
+
+
+def test_round_trip_point_to_cell_to_point():
+    cell = cell_for_point(317, 133, 3, 3, region=REGION)
+    assert cell is not None
+    back = point_for_cell(cell.label, 3, 3, region=REGION)
+    again = cell_for_point(back[0], back[1], 3, 3, region=REGION)
+    assert again.label == cell.label
+
+
+def test_screen_size_default_origin():
+    cells = grid_cells(1, 2, screen_size=[200, 100])
+    assert cells[0].left == 0 and cells[1].right == 200
+    assert cells[0].bottom == 100
+
+
+def test_spreadsheet_labels_past_z():
+    cells = grid_cells(1, 27, region=[0, 0, 270, 10])
+    assert cells[25].label == "Z1"
+    assert cells[26].label == "AA1"
+
+
+def test_invalid_shape_and_label_raise():
+    with pytest.raises(ValueError):
+        grid_cells(0, 4, region=REGION)
+    with pytest.raises(ValueError):
+        point_for_cell("Z9", 2, 2, region=REGION)
+    with pytest.raises(ValueError):
+        point_for_cell("nope", 2, 2, region=REGION)
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_grid_cells", "AC_cell_for_point", "AC_point_for_cell"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_grid_cells", "ac_cell_for_point", "ac_point_for_cell"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_grid_cells", "AC_cell_for_point", "AC_point_for_cell"} <= specs
+
+
+def test_facade_exports():
+    for name in ("grid_cells", "cell_for_point", "point_for_cell", "GridCell"):
+        assert hasattr(ac, name) and name in ac.__all__

--- a/test/unit_test/headless/test_soft_assert_batch.py
+++ b/test/unit_test/headless/test_soft_assert_batch.py
@@ -8,7 +8,7 @@ from je_auto_control.utils.soft_assert import SoftAssertions
 
 def test_all_pass_does_not_raise():
     with SoftAssertions() as soft:
-        soft.check(1 == 1, "one")
+        soft.check(2 > 1, "one")
         soft.check_equal("ok", "ok")
     assert soft.passed == 2 and soft.failures == []
 

--- a/test/unit_test/headless/test_soft_assert_batch.py
+++ b/test/unit_test/headless/test_soft_assert_batch.py
@@ -1,0 +1,71 @@
+"""Headless tests for soft assertions. No Qt."""
+import pytest
+
+import je_auto_control as ac
+from je_auto_control.utils.exception.exceptions import AutoControlActionException
+from je_auto_control.utils.soft_assert import SoftAssertions
+
+
+def test_all_pass_does_not_raise():
+    with SoftAssertions() as soft:
+        soft.check(1 == 1, "one")
+        soft.check_equal("ok", "ok")
+    assert soft.passed == 2 and soft.failures == []
+
+
+def test_aggregates_failures_on_exit():
+    with pytest.raises(AutoControlActionException) as excinfo:
+        with SoftAssertions() as soft:
+            soft.check(True, "a")
+            soft.check(False, "b failed")
+            soft.check_equal(1, 2, "c failed")
+    message = str(excinfo.value)
+    assert "b failed" in message and "c failed" in message
+    assert "2 soft assertion" in message
+
+
+def test_check_returns_bool_and_records():
+    soft = SoftAssertions(raise_on_exit=False)
+    assert soft.check(True) is True
+    assert soft.check(False, "nope") is False
+    assert soft.passed == 1 and soft.failures == ["nope"]
+
+
+def test_exit_does_not_mask_existing_exception():
+    with pytest.raises(KeyError):
+        with SoftAssertions() as soft:
+            soft.check(False, "would-fail")
+            raise KeyError("real error")        # must propagate, not aggregated
+
+
+def test_manual_assert_all():
+    soft = SoftAssertions(raise_on_exit=False)
+    soft.check(False, "x")
+    with pytest.raises(AutoControlActionException):
+        soft.assert_all()
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    assert "AC_soft_assert" in set(ac.executor.known_commands())
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert "ac_soft_assert" in names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert "AC_soft_assert" in specs
+
+
+def test_executor_aggregates_checks():
+    from je_auto_control.utils.executor.action_executor import _soft_assert
+    result = _soft_assert([
+        {"value": 5, "op": "gt", "expected": 3, "message": "five>three"},
+        {"value": "abc", "op": "contains", "expected": "z", "message": "no z"},
+        {"value": 0, "op": "truthy", "message": "zero falsy"}])
+    assert result["ok"] is False and result["passed"] == 1
+    assert "no z" in result["failures"] and "zero falsy" in result["failures"]
+
+
+def test_facade_exports():
+    assert hasattr(ac, "SoftAssertions") and "SoftAssertions" in ac.__all__

--- a/test/unit_test/headless/test_window_geometry_batch.py
+++ b/test/unit_test/headless/test_window_geometry_batch.py
@@ -1,0 +1,50 @@
+"""Headless tests for window client-area geometry. No Qt; reader is injected."""
+import je_auto_control as ac
+from je_auto_control.utils.window_geometry import (
+    client_point, client_to_screen, frame_insets, get_client_rect,
+)
+
+
+def test_frame_insets():
+    # window (100,100)-(300,250); client inset by an 8px border + 22px title bar
+    insets = frame_insets((100, 100, 200, 150), (108, 122, 184, 120))
+    assert insets == {"left": 8, "top": 22, "right": 8, "bottom": 8}
+
+
+def test_client_to_screen():
+    assert client_to_screen((108, 122, 184, 120), 10, 5) == (118, 127)
+
+
+def test_get_client_rect_uses_reader():
+    rect = get_client_rect("Editor", reader=lambda title: (108, 122, 184, 120))
+    assert rect == (108, 122, 184, 120)
+
+
+def test_get_client_rect_none_when_missing():
+    assert get_client_rect("Nope", reader=lambda title: None) is None
+
+
+def test_client_point_maps_into_window():
+    point = client_point("Editor", 20, 30,
+                         reader=lambda title: (108, 122, 184, 120))
+    assert point == (128, 152)
+    assert client_point("Gone", 1, 1, reader=lambda title: None) is None
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_get_client_rect", "AC_client_point"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_get_client_rect", "ac_client_point"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_get_client_rect", "AC_client_point"} <= specs
+
+
+def test_facade_exports():
+    for attr in ("frame_insets", "client_to_screen", "get_client_rect",
+                 "client_point"):
+        assert hasattr(ac, attr) and attr in ac.__all__

--- a/test/unit_test/headless/test_window_zorder_batch.py
+++ b/test/unit_test/headless/test_window_zorder_batch.py
@@ -1,0 +1,67 @@
+"""Headless tests for window z-order control. No Qt; driver is injected."""
+import je_auto_control as ac
+from je_auto_control.utils.window_zorder import (
+    available_actions, bring_to_front, plan_zorder, send_to_back, set_topmost,
+)
+
+
+def _recorder():
+    calls = []
+
+    def driver(title, action):
+        calls.append((title, action))
+        return True
+
+    return driver, calls
+
+
+def test_plan_zorder_maps_constants():
+    assert plan_zorder("top")["insert_after"] == 0
+    assert plan_zorder("bottom")["insert_after"] == 1
+    assert plan_zorder("topmost")["insert_after"] == -1
+    assert plan_zorder("notopmost")["insert_after"] == -2
+    assert plan_zorder("top")["flags"] == ["SWP_NOMOVE", "SWP_NOSIZE"]
+
+
+def test_plan_zorder_unknown_raises():
+    try:
+        plan_zorder("sideways")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")
+
+
+def test_set_topmost_on_and_off():
+    driver, calls = _recorder()
+    assert set_topmost("Editor", True, driver=driver) is True
+    assert set_topmost("Editor", False, driver=driver) is True
+    assert calls == [("Editor", "topmost"), ("Editor", "notopmost")]
+
+
+def test_bring_to_front_and_send_to_back():
+    driver, calls = _recorder()
+    bring_to_front("Editor", driver=driver)
+    send_to_back("Editor", driver=driver)
+    assert calls == [("Editor", "top"), ("Editor", "bottom")]
+
+
+def test_available_actions():
+    assert set(available_actions()) == {"top", "bottom", "topmost", "notopmost"}
+
+
+# --- wiring ---------------------------------------------------------------
+
+def test_wiring():
+    known = set(ac.executor.known_commands())
+    assert {"AC_set_topmost", "AC_bring_to_front", "AC_send_to_back"} <= known
+    from je_auto_control.utils.mcp_server.tools import build_default_tool_registry
+    names = {t.name for t in build_default_tool_registry()}
+    assert {"ac_set_topmost", "ac_bring_to_front", "ac_send_to_back"} <= names
+    from je_auto_control.gui.script_builder.command_schema import _build_specs
+    specs = {s.command for s in _build_specs()}
+    assert {"AC_set_topmost", "AC_bring_to_front", "AC_send_to_back"} <= specs
+
+
+def test_facade_exports():
+    for attr in ("plan_zorder", "set_topmost", "bring_to_front", "send_to_back"):
+        assert hasattr(ac, attr) and attr in ac.__all__


### PR DESCRIPTION
## Release — round-12 MED tier complete

Ships the full round-12 MED-tier backlog to `main`: **16 net-new features** (#356–#371, docs v145–v160), all merged to `dev` CI-green (SonarCloud quality gate + Codacy issues=0 + GitHub Actions matrices + Docker headless image). Each feature ships the full 5-layer surface (headless core → facade → `AC_*` executor → MCP tool → Script Builder) + a headless unit test + EN/Zh docs + changelog entries.

### Vision / image
- **img_histogram** (v145) — colour-histogram fingerprint + change detection (illumination-robust).
- **motion_regions** (v146) — absdiff change boxes + activity score.
- **perceptual_diff** (v149) — YIQ pixelmatch metric with anti-alias suppression.
- **barcode** (v157) — `read_barcodes` 1-D EAN/UPC/Code-128 via `cv2.barcode`, injectable decoder.
- **rotated_match** (v158) — rotation+scale-tolerant template matching (`warpAffine` angle sweep × scale-space).
- **screen_grid** (v159) — coarse labelled cell grid for VLM grounding (point ↔ cell).

### Window
- **window_zorder** (v147) — topmost / bring-to-front / send-to-back planning + Win32 driver.
- **window_geometry** (v150) — client rect + frame insets + client→screen mapping.

### Agent / grounding
- **cua_action** (v151) — normalize Anthropic/OpenAI computer-use payloads → `AC_*`.
- **observation** (v152) — token-budgeted indexed a11y observation.
- **action_grounding** (v153) — validate-action bounds guard + snap-to-element.
- **agent_replay** (v154) — JSONL obs→action trace + deterministic replay.
- **element_diff** (v155) — IoU frame-to-frame element matching + stable IDs.
- **element_scoring** (v156) — weighted role+name-fuzzy+proximity candidate scoring.

### Assertions / clipboard
- **soft_assert** (v148) — scoped soft-assertion accumulator.
- **clipboard_files** (v160) — `CF_HDROP` file-drop list (pure DROPFILES packing + Win32 set/get).

Merge with `--merge` (no branch delete; `dev` stays the working branch).