### PR TITLE
Docs: cross-platform reliability hardening notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,26 @@ only when documented here with a migration path.
 ### Changed
 
 - Releases are prepared from version tags and use PyPI Trusted Publishing.
+- The USB/IP server binds `127.0.0.1` by default (least-privilege). Exporting
+  the attached device to the LAN now requires an explicit `host="0.0.0.0"`.
 
 ### Deprecated
 
 - New integrations should avoid the eager, historical top-level import surface
   and import stable entry points from `je_auto_control.api`.
+
+### Fixed
+
+- macOS cursor position and omitted-coordinate clicks on Retina / HiDPI
+  displays (pixel-vs-point display-height mismatch).
+- Remote-desktop relay hang on Linux + CPython 3.14 when one paired peer
+  disconnected (a cross-thread `shutdown()` no longer wakes a blocked `recv()`).
+- `AC_expect_poll` crashing on a not-ready value instead of continuing to poll;
+  `AC_parallel` branch variable-scope isolation; malformed `run_suite` specs now
+  report a clean error instead of aborting.
+- Windows Interception backend send-to-window click silently no-opping.
+- Wayland partial-coordinate `mouse_scroll` raising instead of degrading.
+- Action-file save now raises `AutoControlJsonActionException` (not a raw
+  `UnicodeEncodeError`) on non-encodable text; non-ASCII USB/IP busid no longer
+  kills the client thread; SQLite connections are closed; USB ACL removal is
+  case-insensitive.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@
 
 ## What's New
 
-All per-release notes have moved to **[WHATS_NEW.md](WHATS_NEW.md)**.
+**Latest (2026-07-18) — cross-platform reliability hardening.** A full-project runtime audit fixed execution-time defects across the macOS / Windows / Linux / Wayland backends, the executor, and the remote-desktop / USB stacks — correct Retina cursor math, a relay hang on CPython 3.14, `AC_expect_poll` / `AC_parallel` robustness, localhost-by-default USB/IP, and typed exceptions preserved at I/O boundaries — each covered by a headless regression test. No API changes.
+
+All per-release notes are in **[WHATS_NEW.md](WHATS_NEW.md)**.
 
 ## Features
 

--- a/README/README_zh-CN.md
+++ b/README/README_zh-CN.md
@@ -56,7 +56,9 @@
 
 ## 本次更新
 
-所有各版本更新说明已移至 **[WHATS_NEW_zh-CN.md](WHATS_NEW_zh-CN.md)**。
+**最新（2026-07-18）— 跨平台稳定性强化。** 一次全项目运行期审计修正了 macOS／Windows／Linux／Wayland 各后端、执行器,以及远程桌面／USB 堆栈的运行期缺陷——包含正确的 Retina 光标坐标运算、CPython 3.14 上的中继卡死、`AC_expect_poll`／`AC_parallel` 的健壮性、USB/IP 默认绑定本机,以及在 I/O 边界保留类型化异常——每项均有 headless 回归测试覆盖。无 API 变更。
+
+各版本更新说明详见 **[WHATS_NEW.md](../WHATS_NEW.md)**。
 
 ## 功能特性
 

--- a/README/README_zh-TW.md
+++ b/README/README_zh-TW.md
@@ -56,7 +56,9 @@
 
 ## 本次更新
 
-所有各版本更新說明已移至 **[WHATS_NEW_zh-TW.md](WHATS_NEW_zh-TW.md)**。
+**最新（2026-07-18）— 跨平台穩定性強化。** 一次全專案執行期稽核修正了 macOS／Windows／Linux／Wayland 各後端、執行器,以及遠端桌面／USB 堆疊的執行期缺陷——包含正確的 Retina 游標座標運算、CPython 3.14 上的中繼卡死、`AC_expect_poll`／`AC_parallel` 的健全性、USB/IP 預設綁定本機,以及在 I/O 邊界保留型別化例外——每項皆有 headless 回歸測試涵蓋。無 API 變更。
+
+各版本更新說明詳見 **[WHATS_NEW.md](../WHATS_NEW.md)**。
 
 ## 功能特色
 

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,20 @@
 # What's New — AutoControl
 
+## What's new (2026-07-18)
+
+### Cross-Platform Reliability Hardening
+
+A full-project runtime audit swept every platform backend and utility for execution-time defects and unexpected behaviour, adding a headless regression test for each fix. There are **no API changes** — existing scripts keep working, they just fail less and behave correctly in more places.
+
+- **macOS (Retina / HiDPI)**: mouse-position reads and omitted-coordinate clicks now land at the correct point. The cursor y-flip used a *pixel*-based display height against a *point*-based cursor, offsetting every implicit click on a 2× display.
+- **Remote-desktop relay**: fixed a hang on **Linux + CPython 3.14** where a paired pipe never exited after one peer disconnected — a cross-thread `shutdown()` no longer reliably wakes a blocked `recv()` there, so the pump now polls readability with `select()` and always re-checks its stop flag.
+- **USB/IP server** now binds `127.0.0.1` by default (least-privilege); export the device to the LAN with an explicit `host="0.0.0.0"`.
+- **Executor**: `AC_expect_poll` no longer crashes on a not-ready value (missing result key or a transiently-failing action) and keeps polling; `AC_parallel` branches are properly variable-scope-isolated, so a nested `AC_execute_action` can't race on the parent's scope; a malformed `run_suite` spec reports a clean error instead of aborting the run.
+- **Windows Interception backend**: send-to-window click now performs a real press/release instead of silently no-opping on the button tuple.
+- **Wayland**: a partial-coordinate `mouse_scroll` degrades gracefully instead of raising `NotImplementedError`.
+- **Typed exceptions preserved at boundaries**: saving an action file with non-encodable text raises `AutoControlJsonActionException` (not a raw `UnicodeEncodeError`); a non-ASCII USB/IP busid no longer kills the client worker thread; SQLite data-source / query connections are always closed; USB ACL rule removal is case-insensitive to match the (case-insensitive) rule matching.
+- Builds on the round-3 sweep that reparented the exception family under `AutoControlException` (assertions still propagate under `raise_on_error=False`) and hardened thread-safety across the socket server, scheduler, triggers, and MCP server.
+
 ## What's new (2026-07-03)
 
 ### Stable API, Failure Bundles, and Release Engineering


### PR DESCRIPTION
Follow-up to #455 (which merged the round-3 + round-4 runtime hardening into `dev`). This doc commit was pushed just after that merge, so it missed it.

Documents the hardening pass — no code changes:
- **WHATS_NEW.md** — dated `2026-07-18` entry with the user-visible fixes (Retina cursor, Linux/CPython 3.14 relay hang, `AC_expect_poll`/`AC_parallel` robustness, localhost-default USB/IP, typed-exception boundaries).
- **CHANGELOG.md** — `Fixed` section + a `Changed` note (USB/IP now binds `127.0.0.1` by default).
- **README.md / README_zh-TW.md / README_zh-CN.md** — synced "What's New" summary; the translated READMEs now point at the real `WHATS_NEW.md` (the `WHATS_NEW_zh-*.md` links were dead).

Docs-only; CI checks that exercise code are unaffected.