### PR TITLE
Bump brace-expansion out of the exponential-expansion DoS range

### DIFF
--- a/autocontrol-lsp/vscode/package-lock.json
+++ b/autocontrol-lsp/vscode/package-lock.json
@@ -485,9 +485,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Closes the one Dependabot alert that is fixable inside the repo: `brace-expansion` 2.1.0 → 2.1.2 in `autocontrol-lsp/vscode/package-lock.json` (CVE-2026-13149, dev scope, reached only when building the VS Code extension). Lockfile-only change via `npm update brace-expansion --package-lock-only`; `npm audit` reports 0 vulnerabilities afterwards.

The other 13 open alerts are all pillow CVEs attributed to `requirements.txt`. They are not fixable by editing this repo: `requirements.txt` lists `je_auto_control` unpinned, which resolves to the published 0.0.214 (2026-06-26), and that release still pins `pillow==12.2.0`. `main` already carries `pillow==12.3.0` — the alerts close when a release ships it.