### PR TITLE
Bump brace-expansion out of the exponential-expansion DoS range

### DIFF
--- a/autocontrol-lsp/vscode/package-lock.json
+++ b/autocontrol-lsp/vscode/package-lock.json
@@ -485,9 +485,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Carries #463 to the default branch, which is the one Dependabot's alerts track: `brace-expansion` 2.1.0 → 2.1.2 in the VS Code extension lockfile (CVE-2026-13149, dev scope).