### PR TITLE
Give the release smoke test a display and the installed wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,17 @@ jobs:
       - run: python -m twine check dist/*
       - name: Smoke-test the built wheel
         run: |
+          # The X11 backend opens a display at import time, so the runner
+          # needs a virtual one. Import from outside the checkout as well:
+          # the repo root shadows site-packages on sys.path, so running this
+          # here would test the source tree instead of the built wheel.
+          sudo apt-get update && sudo apt-get install -y xvfb
           python -m venv /tmp/wheel-test
           /tmp/wheel-test/bin/pip install dist/*.whl
-          /tmp/wheel-test/bin/python -c "import je_auto_control.api"
+          cd /tmp && xvfb-run -a /tmp/wheel-test/bin/python -c "
+          import je_auto_control, je_auto_control.api
+          print('imported', je_auto_control.__file__)
+          "
       - uses: actions/attest-build-provenance@v2
         with:
           subject-path: "dist/*"


### PR DESCRIPTION
The first real run of the tag-triggered release path (`v0.0.215`) failed in `build`, so nothing was published:

```
Xlib.error.DisplayConnectionError: Can't connect to display ":0": [Errno 111] Connection refused
```

Two defects in the same step, both dating from when publishing moved to `release.yml` (this path had never actually run):

1. The X11 backend opens a display at import time. `platform-smoke.yml` installs xvfb for exactly this reason; `release.yml` did not.
2. The traceback frames were all `/home/runner/work/AutoControlGUI/AutoControlGUI/je_auto_control/...` — the repo root shadows site-packages on `sys.path`, so the step imported the source tree, not the wheel it had just installed. It was never smoke-testing the artifact.

Now runs under `xvfb-run` from `/tmp` and prints the resolved `__file__` so a regression is visible in the log.