### PR TITLE
Give the release smoke test a display and the installed wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,17 @@ jobs:
       - run: python -m twine check dist/*
       - name: Smoke-test the built wheel
         run: |
+          # The X11 backend opens a display at import time, so the runner
+          # needs a virtual one. Import from outside the checkout as well:
+          # the repo root shadows site-packages on sys.path, so running this
+          # here would test the source tree instead of the built wheel.
+          sudo apt-get update && sudo apt-get install -y xvfb
           python -m venv /tmp/wheel-test
           /tmp/wheel-test/bin/pip install dist/*.whl
-          /tmp/wheel-test/bin/python -c "import je_auto_control.api"
+          cd /tmp && xvfb-run -a /tmp/wheel-test/bin/python -c "
+          import je_auto_control, je_auto_control.api
+          print('imported', je_auto_control.__file__)
+          "
       - uses: actions/attest-build-provenance@v2
         with:
           subject-path: "dist/*"


### PR DESCRIPTION
Carries #465 to `main` so `v0.0.215` can be re-cut: the wheel smoke test now runs under `xvfb-run` and from `/tmp`, so it exercises the installed wheel instead of the repo checkout.