### PR TITLE
Put releases back on merges to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,14 @@ jobs:
 
   publish:
     needs: build
+    # Publishing happens on merge to main (stable.yml), so this path stays
+    # off: the tags stable.yml pushes would otherwise start a second upload
+    # of a version PyPI already has. The build job above still runs on every
+    # v* tag — it verifies the tag matches pyproject, smoke-tests the wheel
+    # and attests provenance. To go back to tag-driven releases, register a
+    # PyPI trusted publisher for release.yml, drop this condition, and put
+    # stable.yml's publish job back behind `if: ${{ false }}`.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -118,8 +118,12 @@ jobs:
 
   publish:
     needs: test
-    # Publishing moved to release.yml: immutable v* tags + Trusted Publishing.
-    if: ${{ false }}
+    # Releases ride on merges to main: this job bumps the patch version,
+    # uploads to PyPI with the PYPI_API_TOKEN secret, then pushes the bump
+    # commit (marked [skip ci]) and its v* tag. The guard is what keeps it
+    # off pull requests and the nightly schedule, which the same workflow
+    # also triggers on — without it every PR would cut a release.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Reverts the release trigger to the pre-#455 rhythm: **merge to `main` → publish**.

- `stable.yml`'s publish job gets its original guard back (`github.event_name == 'push' && github.ref == 'refs/heads/main'`), exactly as it read before 7ddac38 disabled it. The guard is load-bearing — the workflow also runs on `pull_request` and a nightly `schedule`, so an unguarded job would cut a release from every PR and every night.
- Auth needs nothing new: the `PYPI_API_TOKEN` secret is still present (updated 2026-04-21) and the job uploads with twine, so this does not depend on the PyPI trusted-publisher registration that `v0.0.215` failed on.
- `release.yml`'s upload is switched off so the tag `stable.yml` pushes cannot start a second upload of a version PyPI already has. Its `build` job still runs on every `v*` tag: verify tag matches pyproject, smoke-test the wheel, attest provenance.

**What happens when this reaches `main`:** the publish job fires on the merge, bumps `0.0.215` → `0.0.216`, uploads to PyPI, pushes the bump commit (`[skip ci]`) and tag `v0.0.216`, and creates the GitHub Release. That published version carries `pillow==12.3.0`, which is what closes the 13 open Dependabot alerts.

The unused `v0.0.215` tag is deleted separately — nothing was ever published under it, and the auto-bump will produce `v0.0.216`.