### PR TITLE
Floor je_auto_control at the release that fixes the pillow CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-je_auto_control
+# Floor, not a pin: releases before 0.0.216 resolve pillow==12.2.0, which
+# carries 13 CVEs fixed in 12.3.0. A floor keeps the dependency graph honest
+# without needing a bump here on every release.
+je_auto_control>=0.0.216
 qt-material==2.17
 mss==10.2.0
 PySide6==6.11.1


### PR DESCRIPTION
The 13 pillow alerts did not close after publishing 0.0.216, and they were not going to.

`requirements.txt` listed `je_auto_control` with no constraint, so GitHub's dependency graph resolved it to the published release and recorded its transitive `pillow==12.2.0`. GitHub re-resolves a pip manifest **when the file changes**, not when a transitive dependency's upstream ships a fix — every alert still reads `updated_at: 2026-07-21` while `pyproject.toml` and `uv.lock` moved to 12.3.0 today. The SBOM shows both entries side by side: `pillow 12.2.0` (from requirements.txt) and `pillow 12.3.0` (from the pinned manifests).

A floor rather than a pin: it states the real requirement (0.0.216 is the first release carrying `pillow==12.3.0`), forces the re-resolution that closes the alerts, and does not need editing on every release — which matters now that merging to main cuts one.