### PR TITLE
Close the pillow alerts and widen the no-AI-attribution rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ Features that are inherently interactive (e.g. region picking with the mouse, te
 ## Commit Conventions
 
 - Write concise commit messages focused on **why**, not what.
-- **Do not mention any AI tools, assistants, or models in commit messages** — no "Co-Authored-By" AI attributions, no references to AI-generated code.
+- **No AI attribution anywhere.** Not in commit messages, pull request titles or bodies, issue and review comments, release notes, code comments, or documentation. Specifically forbidden: `Co-Authored-By:` lines naming an assistant, "Generated with …" / "Created by …" footers, tool badges, links to assistant products, emoji markers standing in for the same thing, and any statement that code was AI-generated. Everything published under this repo reads as the author's own work.
 - Use imperative mood: "Add feature", "Fix bug", "Remove unused code".
 - Examples:
   - `Add image threshold parameter validation`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-je_auto_control
+# Floor, not a pin: releases before 0.0.216 resolve pillow==12.2.0, which
+# carries 13 CVEs fixed in 12.3.0. A floor keeps the dependency graph honest
+# without needing a bump here on every release.
+je_auto_control>=0.0.216
 qt-material==2.17
 mss==10.2.0
 PySide6==6.11.1


### PR DESCRIPTION
Carries #469 and #470 to the default branch.

#469 is the one that matters for the open alerts: `requirements.txt` now floors `je_auto_control` at 0.0.216. GitHub re-resolves a pip manifest when the file changes, not when a transitive dependency's upstream ships a fix, so the 13 pillow alerts have sat at `updated_at: 2026-07-21` through every release today. Landing the changed manifest on the default branch is what forces the re-resolution.

Merging also cuts 0.0.217 through `stable.yml`, which is the expected rhythm now.